### PR TITLE
Fixed workflow errors that occur if PR list is empty

### DIFF
--- a/.github/workflows/synchronise-trunk-version-npm.yml
+++ b/.github/workflows/synchronise-trunk-version-npm.yml
@@ -37,6 +37,7 @@ jobs:
           echo "pr_list=$PR_LIST" >> $GITHUB_OUTPUT
   synchronise-pull-requests:
     needs: find-pull-requests
+    if: ${{ join(fromJSON(needs.find-pull-requests.outputs.pr_list), '') != '' }}
     strategy:
       matrix:
         pr_number: ${{ fromJSON(needs.find-pull-requests.outputs.pr_list) }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

ENG-72

## High level description

When the synchronise version trunk workflow runs on main if there are no PRs to update it errors as the matrix strategy is empty. This fixes that by only running if the list is non empty

## Detailed description

N/A

## Describe alternatives you've considered

Instead of doing the `join` on the list and comparing to empty string I considered creating another output from the previous jon of the number of PRs found. This could be done with `jq` and would be valid if the reviewer prefers it.

## Operational impact

None

## Additional context

None
