### PR TITLE
Add permission for private repo Github releases

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -8,6 +8,7 @@ on:
         default: '{}'
 permissions:
   contents: write
+  pull-requests: read
 jobs:
   release:
     name: 'Release'


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/ENG-102

## High level description

When github release runs on private repos, it needs permission to read pull requests history

see successful run https://github.com/digicatapult/dtdl-visualisation-tool/pull/86/commits/6c97780f059531c912cbf98dc79bea77a5687929

actions reads pull requests in this step
```

Generating changelog
  Found 1 pull request(s) associated with commit e5dcb71651bfbcb8360b116e37b4ae06282744e5
```

unsuccessful run before with fewer permissions https://github.com/digicatapult/dtdl-visualisation-tool/pull/86/commits/20b4b0caa0c76a14d8c53336e0e18e3bcd7651ba