### PR TITLE
Add support for adding build args to the docker build commands

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,10 +2,14 @@ name: Build Docker
 on:
   workflow_call:
     inputs:
+      build_args:
+        required: false
+        type: string
+        default: ""
       env_vars:
         required: false
         type: string
-        default: '{}'
+        default: "{}"
       push_dockerhub:
         required: false
         type: boolean
@@ -50,7 +54,7 @@ jobs:
           echo "REPO_NAME=$REPO_NAME" >> $GITHUB_OUTPUT
           echo "ORG_NAME=$ORG_NAME" >> $GITHUB_OUTPUT
   build-docker:
-    name: 'Build docker image'
+    name: "Build docker image"
     needs: repo_ids
     runs-on: ubuntu-latest
     steps:
@@ -73,7 +77,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
         with:
-          buildkitd-flags: '--debug'
+          buildkitd-flags: "--debug"
       - name: Generate tags
         id: generate-tags
         if: ${{ inputs.push_dockerhub == true || inputs.push_ghcr == true }}
@@ -128,6 +132,7 @@ jobs:
           context: .
           file: ${{ inputs.docker_file }}
           platforms: ${{ inputs.docker_platforms }}
+          build-args: ${{ inputs.build_args }}
           push: true
           tags: |
             ghcr.io/${{ needs.repo_ids.outputs.org_name }}/${{ needs.repo_ids.outputs.repo_name }}:${{ github.sha }}
@@ -150,6 +155,7 @@ jobs:
           context: .
           file: ${{ inputs.docker_file }}
           platforms: ${{ inputs.docker_platforms }}
+          build-args: ${{ inputs.build_args }}
           push: true
           tags: |
             ${{ needs.repo_ids.outputs.org_name }}/${{ needs.repo_ids.outputs.repo_name }}:${{ github.sha }}
@@ -172,6 +178,7 @@ jobs:
           context: .
           file: ${{ inputs.docker_file }}
           platforms: ${{ inputs.docker_platforms }}
+          build-args: ${{ inputs.build_args }}
           push: true
           tags: |
             ghcr.io/${{ needs.repo_ids.outputs.org_name }}/${{ needs.repo_ids.outputs.repo_name }}:${{ github.sha }}
@@ -197,4 +204,5 @@ jobs:
           context: .
           file: ${{ inputs.docker_file }}
           platforms: ${{ inputs.docker_platforms }}
+          build-args: ${{ inputs.build_args }}
           push: false


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-50

## High level description

Adds support for passing build args through to the docker build command

## Detailed description

Thankfully this is much simpler than env handling as it's being passed through as a string and doesn't need parsing to a map

## Describe alternatives you've considered

None

## Operational impact

Could break all docker builds if I've messed up. If so the PR can simply be reverted

## Additional context

N/A
