### PR TITLE
Replace release action

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -33,7 +33,6 @@ jobs:
           draft: false
           prerelease: false
           make_latest: true
-          generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update latest tag
         run: |

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -37,7 +37,12 @@ jobs:
           PR_NUMBER=$(gh pr list --state merged --base main --limit 1 --json number --jq '.[0].number')
           echo "Fetching body for PR #$PR_NUMBER"
 
-          BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json title,url,body --jq '{title, url, body}')
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+          BODY=$(echo "$PR_JSON" | jq -r '.body')
+
+          echo "**[$PR_TITLE]($PR_URL)**" >> $GITHUB_OUTPUT
 
           echo "$BODY" | awk '
             BEGIN { section = "" }

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -33,6 +33,7 @@ jobs:
           draft: false
           prerelease: false
           make_latest: true
+          generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update latest tag
         run: |
@@ -48,4 +49,5 @@ jobs:
           name: Latest Release ${{ steps.get_version.outputs.version }}
           draft: false
           prerelease: false
+          generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -35,6 +35,13 @@ jobs:
           make_latest: true
           generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update latest tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch --tags
+          git tag -f latest
+          git push origin -f latest
       - name: Create GitHub release latest
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,6 +25,33 @@ jobs:
         uses: digicatapult/check-version@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate release notes from PR body
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+
+          echo "## Changes" >> $GITHUB_OUTPUT
+
+          PR_NUMBER=$(gh pr list --state merged --base main --limit 1 --json number --jq '.[0].number')
+          echo "Fetching body for PR #$PR_NUMBER"
+
+          BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+
+          echo "$BODY" | awk '
+            BEGIN { section = "" }
+
+            /^## Linked tickets/         { section = "### Linked Tickets"; print "\n" section; next }
+            /^## High level description/ { section = "### High Level Description"; print "\n" section; next }
+            /^## Detailed description/   { section = "### Detailed Description"; print "\n" section; next }
+
+            /^## / { section = ""; next }
+
+            { if (section != "") print $0 }
+          ' >> $GITHUB_OUTPUT
+
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Create GitHub release version
         uses: softprops/action-gh-release@v2
         with:
@@ -33,7 +60,7 @@ jobs:
           draft: false
           prerelease: false
           make_latest: true
-          generate_release_notes: true
+          body: ${{ steps.release_notes.outputs.body }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update latest tag
         run: |
@@ -50,4 +77,5 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+          body: ${{ steps.release_notes.outputs.body }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,17 +25,22 @@ jobs:
         uses: digicatapult/check-version@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build release version
-        uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Create GitHub release version
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.get_version.outputs.version }}
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          draft: false
           prerelease: false
-          title: Release ${{ steps.get_version.outputs.version }}
-      - name: Build release latest
-        uses: "marvinpinto/action-automatic-releases@latest"
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub release latest
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: latest
+          tag_name: latest
+          name: Latest Release ${{ steps.get_version.outputs.version }}
+          draft: false
           prerelease: false
-          title: Latest Release ${{ steps.get_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -35,11 +35,3 @@ jobs:
           make_latest: true
           generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create GitHub release latest
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: latest
-          name: Latest Release ${{ steps.get_version.outputs.version }}
-          draft: false
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -35,3 +35,11 @@ jobs:
           make_latest: true
           generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub release latest
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest Release ${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -33,8 +33,8 @@ jobs:
           draft: false
           prerelease: false
           make_latest: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GitHub release latest
         uses: softprops/action-gh-release@v2
         with:
@@ -42,5 +42,4 @@ jobs:
           name: Latest Release ${{ steps.get_version.outputs.version }}
           draft: false
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Chore

## Linked tickets

ENG-138

## High level description

Replaces the marvinpinto github release action with a different maintained action.

## Detailed description

Uses the softprops github action https://github.com/softprops/action-gh-release/
Adds a step which force pushes the latest tag to the newly created version.
Adds a step to create the release notes from the PR

Example of this working can be found in releases 6.1.15 and latest on this example repo.
https://github.com/dblane-digicatapult/sqnc-matchmaker-api/releases
https://github.com/dblane-digicatapult/sqnc-matchmaker-api/releases/tag/v6.1.15

## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
