### PR TITLE
VR-299 Don't pass company house API key to e2e tests

### DIFF
--- a/.github/workflows/tests-e2e-npm.yml
+++ b/.github/workflows/tests-e2e-npm.yml
@@ -67,8 +67,6 @@ jobs:
         if: ${{ !(github.event.repository.name == 'veritable-ui' || github.event.repository.name == 'dtdl-visualisation-tool') }}
       - name: Run e2e tests - veritable UI
         run: ${{ inputs.test_command }}
-        env:
-          VERITABLE_COMPANY_PROFILE_API_KEY: ${{ secrets.COMPANIES_HOUSE_API }}
         if: ${{ github.event.repository.name == 'veritable-ui' }}
       - name: Run e2e tests - dtdl-visualisation-tool
         run: ${{ inputs.test_command }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-299

## High level description

<!-- One paragraph explanation of the feature. -->

## Detailed description

With the corresponding changes in `veritable-ui`, e2e tests no longer require the Company House API key

## Describe alternatives you've considered

## Operational impact


## Additional context

