### PR TITLE
Add coverage to NPM tests

### DIFF
--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm run ${{ matrix.command }}
       - name: Set artifact name
         id: artifact-name
-        run: echo "name=coverage-$(echo '${{ matrix.command }}' | tr -d '\":;<>|*?\r\n\\/' | tr ' ' '-')" >> $GITHUB_OUTPUT
+        run: echo "name=coverage-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT
         if: inputs.coverage
       - name: Upload coverage JSON summary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -187,12 +187,14 @@ jobs:
         with:
           file-coverage-mode: all
           json-summary-compare-path: coverage-main/coverage-summary.json
+          vite-config-path: ""
+          comment-on: none
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-full-html-report
           path: |
             coverage/**
             !coverage/tmp/**

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Setup c8 config
         run: |
           if [ -n "${{ inputs.coverage_config }}" ]; then
-            echo "Using custom config: ${{ inputs.coverage_config }}"
+            echo "Copying repo config '${{ inputs.coverage_config }}' to .c8rc.workflow.json"
             cp ${{ inputs.coverage_config }} .c8rc.workflow.json
           else
-            echo "Using default workflow config"
+            echo "Using default .c8rc.workflow.json"
             cat > .c8rc.workflow.json << 'EOF'
           {
             "temp-directory": "coverage/tmp",
@@ -136,10 +136,10 @@ jobs:
       - name: Setup c8 config
         run: |
           if [ -n "${{ inputs.coverage_config }}" ]; then
-            echo "Using custom config: ${{ inputs.coverage_config }}"
+            echo "Copying repo config '${{ inputs.coverage_config }}' to .c8rc.workflow.json"
             cp ${{ inputs.coverage_config }} .c8rc.workflow.json
           else
-            echo "Using default workflow config"
+            echo "Using default .c8rc.workflow.json"
             echo '{"temp-directory":"coverage/tmp","reporter":["text","html"],"lines":50,"branches":0,"functions":0,"statements":0}' > .c8rc.workflow.json
           fi
 

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -26,6 +26,14 @@ on:
         required: false
         type: string
         default: '["test:unit", "test:integration"]'
+      coverage:
+        required: false
+        type: boolean
+        default: false
+      coverage_path:
+        required: false
+        type: string
+        default: coverage/tmp
 jobs:
   tests:
     name: Run tests - ${{ matrix.command }}
@@ -73,3 +81,40 @@ jobs:
         if: inputs.pre_test_command != ''
       - name: Run tests
         run: npm run ${{ matrix.command }}
+      - name: Upload coverage JSON summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.command }}
+          path: ${{ inputs.coverage_path }}
+        if: inputs.coverage
+
+  coverage-report:
+    runs-on: ubuntu-latest
+    needs: tests
+    if: inputs.coverage
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Download all coverage summaries
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage/tmp
+          merge-multiple: true
+
+      - name: Generate text report
+        run: npx c8 report --reporter=text >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate html report
+        run: npx c8 report --reporter=html
+
+      - name: Upload html report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Fail if under thresholds
+        run: npx c8 check-coverage

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -160,40 +160,31 @@ jobs:
           pattern: coverage-main-*
           merge-multiple: true
 
-      - name: Check for coverage files
-        id: check-coverage
-        run: |
-          if [ ! -d "coverage/tmp" ] || [ -z "$(ls -A coverage/tmp)" ]; then
-            echo "No coverage files found" >> $GITHUB_STEP_SUMMARY
-            echo "has_coverage=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_coverage=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Generate reports
-        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: npx c8 --config .c8rc.workflow.json report --reporter=html --reporter=json-summary --reporter=json
 
       - name: Generate main branch reports
-        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: |
           if [ -d "coverage-main/tmp" ] && [ -n "$(ls -A coverage-main/tmp)" ]; then
-            npx c8 --temp-directory coverage-main/tmp --reports-dir coverage-main --config .c8rc.workflow.json report --reporter=json-summary
+            npx c8 --temp-directory coverage-main/tmp --reports-dir coverage-main --config .c8rc.workflow.json report --reporter=json-summary --reporter=json
           fi
 
-      - name: Create minimal vite config to silence action warning
-        run: echo "export default {}" > vite.config.js
-      - name: Pretty coverage summary
-        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
+      - name: Setup vite config if none exists
+        run: |
+          if ! compgen -G "{vite,vitest}.config.{ts,mts,cts,js,mjs,cjs}" > /dev/null; then
+            echo "No vite config found, creating minimal vite.config.js"
+            echo "export default {}" > vite.config.js
+          else
+            echo "Vite config found"
+          fi
 
+      - name: Pretty coverage summary
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           file-coverage-mode: all
           json-summary-compare-path: coverage-main/coverage-summary.json
-          vite-config-path: ""
 
       - name: Upload html report
-        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-all-html-report
@@ -202,5 +193,4 @@ jobs:
             !coverage/tmp/**
 
       - name: Fail if under thresholds
-        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: npx c8 --config .c8rc.workflow.json check-coverage

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -30,30 +30,10 @@ on:
         required: false
         type: boolean
         default: true
-      coverage_path:
-        required: false
-        type: string
-        default: coverage/tmp
       coverage_config:
         required: false
         type: string
-        default: .c8rc.json
-      coverage_lines:
-        required: false
-        type: number
-        default: 50
-      coverage_branches:
-        required: false
-        type: number
-        default: 0
-      coverage_functions:
-        required: false
-        type: number
-        default: 0
-      coverage_statements:
-        required: false
-        type: number
-        default: 0
+        default: ""
 jobs:
   tests:
     name: Run tests - ${{ matrix.command }}
@@ -83,6 +63,36 @@ jobs:
             ${{ runner.OS }}-
       - name: Install Packages
         run: npm ci
+      - name: Setup c8 config
+        run: |
+          if [ -n "${{ inputs.coverage_config }}" ]; then
+            echo "Using custom config: ${{ inputs.coverage_config }}"
+            cp ${{ inputs.coverage_config }} .c8rc.workflow.json
+          else
+            echo "Using default workflow config"
+            cat > .c8rc.workflow.json << 'EOF'
+          {
+            "temp-directory": "coverage/tmp",
+            "exclude": [
+              "coverage/**",
+              "packages/*/test{,s}/**",
+              "**/*.d.ts",
+              "test{,s}/**",
+              "test{,-*}.js",
+              "**/*{.,-}test.js",
+              "**/__tests__/**",
+              "**/node_modules/**",
+              "**/babel.config.js",
+              "**/*.tsx"
+            ]
+          }
+          EOF
+          fi
+        if: inputs.coverage
+      - name: Get coverage temp directory
+        id: coverage-dir
+        run: echo "path=$(node -pe "require('./.c8rc.workflow.json')['temp-directory'] || 'coverage/tmp'")" >> $GITHUB_OUTPUT
+        if: inputs.coverage
       - name: Build
         run: ${{ inputs.npm_build_command }}
         if: inputs.npm_build_command != ''
@@ -100,7 +110,7 @@ jobs:
         run: ${{ inputs.pre_test_command }}
         if: inputs.pre_test_command != ''
       - name: Run tests
-        run: npx c8 npm run ${{ matrix.command }}
+        run: npx c8 --config .c8rc.workflow.json npm run ${{ matrix.command }}
       - name: Set artifact name
         id: artifact-name
         run: echo "name=coverage-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT
@@ -109,7 +119,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact-name.outputs.name }}
-          path: ${{ inputs.coverage_path }}
+          path: ${{ steps.coverage-dir.outputs.path }}
         if: inputs.coverage
 
   coverage:
@@ -122,6 +132,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
+
+      - name: Setup c8 config
+        run: |
+          if [ -n "${{ inputs.coverage_config }}" ]; then
+            echo "Using custom config: ${{ inputs.coverage_config }}"
+            cp ${{ inputs.coverage_config }} .c8rc.workflow.json
+          else
+            echo "Using default workflow config"
+            echo '{"temp-directory":"coverage/tmp","reporter":["text","html"],"lines":50,"branches":0,"functions":0,"statements":0}' > .c8rc.workflow.json
+          fi
 
       - name: Download all coverage summaries
         uses: actions/download-artifact@v4
@@ -142,11 +162,11 @@ jobs:
 
       - name: Generate text report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
-        run: npx c8 report --reporter=text >> $GITHUB_STEP_SUMMARY
+        run: npx c8 --config .c8rc.workflow.json report --reporter=text >> $GITHUB_STEP_SUMMARY
 
       - name: Generate html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
-        run: npx c8 report --reporter=html
+        run: npx c8 --config .c8rc.workflow.json report --reporter=html
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
@@ -159,11 +179,4 @@ jobs:
 
       - name: Fail if under thresholds
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
-        run: |
-          if [ -f ${{ inputs.coverage_config }} ]; then
-            echo "Using repo config"
-            npx c8 check-coverage
-          else
-            echo "Using workflow thresholds"
-            npx c8 check-coverage --lines ${{ inputs.coverage_lines }} --branches ${{ inputs.coverage_branches }} --functions ${{ inputs.coverage_functions }} --statements ${{ inputs.coverage_statements }}
-          fi
+        run: npx c8 --config .c8rc.workflow.json check-coverage

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -29,11 +29,31 @@ on:
       coverage:
         required: false
         type: boolean
-        default: false
+        default: true
       coverage_path:
         required: false
         type: string
         default: coverage/tmp
+      coverage_config:
+        required: false
+        type: string
+        default: .c8rc.json
+      coverage_lines:
+        required: false
+        type: number
+        default: 50
+      coverage_branches:
+        required: false
+        type: number
+        default: 0
+      coverage_functions:
+        required: false
+        type: number
+        default: 0
+      coverage_statements:
+        required: false
+        type: number
+        default: 0
 jobs:
   tests:
     name: Run tests - ${{ matrix.command }}
@@ -80,7 +100,7 @@ jobs:
         run: ${{ inputs.pre_test_command }}
         if: inputs.pre_test_command != ''
       - name: Run tests
-        run: npm run ${{ matrix.command }}
+        run: npx c8 npm run ${{ matrix.command }}
       - name: Set artifact name
         id: artifact-name
         run: echo "name=coverage-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT
@@ -121,15 +141,15 @@ jobs:
           fi
 
       - name: Generate text report
-        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
+        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: npx c8 report --reporter=text >> $GITHUB_STEP_SUMMARY
 
       - name: Generate html report
-        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
+        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: npx c8 report --reporter=html
 
       - name: Upload html report
-        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
+        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage
@@ -138,5 +158,12 @@ jobs:
             !coverage/tmp/**
 
       - name: Fail if under thresholds
-        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
-        run: npx c8 check-coverage
+        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
+        run: |
+          if [ -f ${{ inputs.coverage_config }} ]; then
+            echo "Using repo config"
+            npx c8 check-coverage
+          else
+            echo "Using workflow thresholds"
+            npx c8 check-coverage --lines ${{ inputs.coverage_lines }} --branches ${{ inputs.coverage_branches }} --functions ${{ inputs.coverage_functions }} --statements ${{ inputs.coverage_statements }}
+          fi

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -178,8 +178,7 @@ jobs:
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: |
           if [ -d "coverage-main/tmp" ] && [ -n "$(ls -A coverage-main/tmp)" ]; then
-            npx c8 --temp-directory coverage-main/tmp --config .c8rc.workflow.json report --reporter=json-summary
-            mv coverage/coverage-summary.json coverage-main/coverage-summary.json
+            npx c8 --temp-directory coverage-main/tmp --reports-dir coverage-main --config .c8rc.workflow.json report --reporter=json-summary
           fi
 
       - name: Pretty coverage summary

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -190,10 +190,10 @@ jobs:
           file-coverage-mode: all
           json-summary-compare-path: coverage-main/coverage-summary.json
 
-      - name: Upload html report
+      - name: Upload reports for current branch
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-all-html-report
+          name: coverage-current-all
           path: |
             coverage/**
             !coverage/tmp/**

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -92,7 +92,8 @@ jobs:
           path: ${{ inputs.coverage_path }}
         if: inputs.coverage
 
-  coverage-report:
+  coverage:
+    name: Coverage
     runs-on: ubuntu-latest
     needs: tests
     if: inputs.coverage

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -185,12 +185,12 @@ jobs:
         run: echo "export default {}" > vite.config.js
       - name: Pretty coverage summary
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
+
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           file-coverage-mode: all
           json-summary-compare-path: coverage-main/coverage-summary.json
           vite-config-path: ""
-          comment-on: commit
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -107,7 +107,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: coverage/tmp
+          pattern: coverage-*
           merge-multiple: true
+
+      - name: Check for coverage files
+        run: |
+          if [ -z "$(ls -A coverage/tmp)" ]; then
+            echo "No coverage files found" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
 
       - name: Generate text report
         run: npx c8 report --reporter=text >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -81,10 +81,14 @@ jobs:
         if: inputs.pre_test_command != ''
       - name: Run tests
         run: npm run ${{ matrix.command }}
+      - name: Set artifact name
+        id: artifact-name
+        run: echo "name=coverage-$(echo '${{ matrix.command }}' | tr -d '\":;<>|*?\r\n\\/' | tr ' ' '-')" >> $GITHUB_OUTPUT
+        if: inputs.coverage
       - name: Upload coverage JSON summary
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.command }}
+          name: ${{ steps.artifact-name.outputs.name }}
           path: ${{ inputs.coverage_path }}
         if: inputs.coverage
 

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -111,19 +111,25 @@ jobs:
           merge-multiple: true
 
       - name: Check for coverage files
+        id: check-coverage
         run: |
-          if [ -z "$(ls -A coverage/tmp)" ]; then
+          if [ ! -d "coverage/tmp" ] || [ -z "$(ls -A coverage/tmp)" ]; then
             echo "No coverage files found" >> $GITHUB_STEP_SUMMARY
-            exit 0
+            echo "has_coverage=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate text report
+        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
         run: npx c8 report --reporter=text >> $GITHUB_STEP_SUMMARY
 
       - name: Generate html report
+        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
         run: npx c8 report --reporter=html
 
       - name: Upload html report
+        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage
@@ -132,4 +138,5 @@ jobs:
             !coverage/tmp/**
 
       - name: Fail if under thresholds
+        if: ${{ steps.check-coverage.outputs.has_coverage == true }}
         run: npx c8 check-coverage

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -93,8 +93,12 @@ jobs:
       - name: Run pre-test command
         run: ${{ inputs.pre_test_command }}
         if: inputs.pre_test_command != ''
-      - name: Run tests
+      - name: Run tests with coverage
         run: npx c8 npm run ${{ matrix.command }}
+        if: inputs.coverage
+      - name: Run tests without coverage
+        run: npm run ${{ matrix.command }}
+        if: ${{ !inputs.coverage }}
       - name: Set artifact name
         id: artifact-name
         run: echo "name=coverage-${{ matrix.branch == 'main' && 'main' || 'current' }}-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -121,8 +121,6 @@ jobs:
             echo "Using default .c8rc.workflow.json"
             cat > .c8rc.workflow.json << 'EOF'
           {
-            "temp-directory": "coverage/tmp",
-            "reporter": ["text", "html"],
             "lines": 50,
             "branches": 0,
             "functions": 0,
@@ -160,13 +158,14 @@ jobs:
             echo "has_coverage=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate text report
+      - name: Generate reports
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
-        run: npx c8 --config .c8rc.workflow.json report --reporter=text >> $GITHUB_STEP_SUMMARY
-
-      - name: Generate html report
+        run: npx c8 --config .c8rc.workflow.json report --reporter=html --reporter=json-summary --reporter=json
+      - name: Pretty coverage summary
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
-        run: npx c8 --config .c8rc.workflow.json report --reporter=html
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          comment-on: commit
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -181,6 +181,8 @@ jobs:
             npx c8 --temp-directory coverage-main/tmp --reports-dir coverage-main --config .c8rc.workflow.json report --reporter=json-summary
           fi
 
+      - name: Create minimal vite config to silence action warning
+        run: echo "export default {}" > vite.config.js
       - name: Pretty coverage summary
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: davelosert/vitest-coverage-report-action@v2
         with:
-          comment-on: commit
+          file-coverage-mode: all
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -36,14 +36,19 @@ on:
         default: ""
 jobs:
   tests:
-    name: Run tests - ${{ matrix.command }}
+    name: Run tests - ${{ matrix.command }} - ${{ matrix.branch }}
     strategy:
       fail-fast: false
       matrix:
         command: ${{ fromJson(inputs.tests) }}
+        branch:
+          - ${{ github.head_ref || github.ref_name }}
+          - main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
       - name: Set environment variables from JSON
         env:
           ENV_VARS_JSON: "${{ inputs.env_vars }}"
@@ -92,7 +97,7 @@ jobs:
         run: npx c8 npm run ${{ matrix.command }}
       - name: Set artifact name
         id: artifact-name
-        run: echo "name=coverage-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT
+        run: echo "name=coverage-${{ matrix.branch == 'main' && 'main' || 'current' }}-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT
         if: inputs.coverage
       - name: Upload coverage JSON summary
         uses: actions/upload-artifact@v4
@@ -141,11 +146,18 @@ jobs:
           EOF
           fi
 
-      - name: Download all coverage summaries
+      - name: Download current branch coverage summaries
         uses: actions/download-artifact@v4
         with:
           path: coverage/tmp
-          pattern: coverage-*
+          pattern: coverage-current-*
+          merge-multiple: true
+
+      - name: Download main branch coverage summaries
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage-main/tmp
+          pattern: coverage-main-*
           merge-multiple: true
 
       - name: Check for coverage files
@@ -161,11 +173,21 @@ jobs:
       - name: Generate reports
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         run: npx c8 --config .c8rc.workflow.json report --reporter=html --reporter=json-summary --reporter=json
+
+      - name: Generate main branch reports
+        if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
+        run: |
+          if [ -d "coverage-main/tmp" ] && [ -n "$(ls -A coverage-main/tmp)" ]; then
+            npx c8 --temp-directory coverage-main/tmp --config .c8rc.workflow.json report --reporter=json-summary
+            mv coverage/coverage-summary.json coverage-main/coverage-summary.json
+          fi
+
       - name: Pretty coverage summary
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           file-coverage-mode: all
+          json-summary-compare-path: coverage-main/coverage-summary.json
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -188,13 +188,13 @@ jobs:
           file-coverage-mode: all
           json-summary-compare-path: coverage-main/coverage-summary.json
           vite-config-path: ""
-          comment-on: none
+          comment-on: commit
 
       - name: Upload html report
         if: ${{ steps.check-coverage.outputs.has_coverage == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-full-html-report
+          name: coverage-all-html-report
           path: |
             coverage/**
             !coverage/tmp/**

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -118,7 +118,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coverage
+          path: |
+            coverage/**
+            !coverage/tmp/**
 
       - name: Fail if under thresholds
         run: npx c8 check-coverage

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -63,35 +63,14 @@ jobs:
             ${{ runner.OS }}-
       - name: Install Packages
         run: npm ci
-      - name: Setup c8 config
-        run: |
-          if [ -n "${{ inputs.coverage_config }}" ]; then
-            echo "Copying repo config '${{ inputs.coverage_config }}' to .c8rc.workflow.json"
-            cp ${{ inputs.coverage_config }} .c8rc.workflow.json
-          else
-            echo "Using default .c8rc.workflow.json"
-            cat > .c8rc.workflow.json << 'EOF'
-          {
-            "temp-directory": "coverage/tmp",
-            "exclude": [
-              "coverage/**",
-              "packages/*/test{,s}/**",
-              "**/*.d.ts",
-              "test{,s}/**",
-              "test{,-*}.js",
-              "**/*{.,-}test.js",
-              "**/__tests__/**",
-              "**/node_modules/**",
-              "**/babel.config.js",
-              "**/*.tsx"
-            ]
-          }
-          EOF
-          fi
-        if: inputs.coverage
       - name: Get coverage temp directory
         id: coverage-dir
-        run: echo "path=$(node -pe "require('./.c8rc.workflow.json')['temp-directory'] || 'coverage/tmp'")" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ inputs.coverage_config }}" ] && [ -f "${{ inputs.coverage_config }}" ]; then
+            echo "path=$(node -pe "require('${{ inputs.coverage_config }}')['temp-directory'] || 'coverage/tmp'")" >> $GITHUB_OUTPUT
+          else
+            echo "path=coverage/tmp" >> $GITHUB_OUTPUT
+          fi
         if: inputs.coverage
       - name: Build
         run: ${{ inputs.npm_build_command }}
@@ -110,7 +89,7 @@ jobs:
         run: ${{ inputs.pre_test_command }}
         if: inputs.pre_test_command != ''
       - name: Run tests
-        run: npx c8 --config .c8rc.workflow.json npm run ${{ matrix.command }}
+        run: npx c8 npm run ${{ matrix.command }}
       - name: Set artifact name
         id: artifact-name
         run: echo "name=coverage-$(echo "${{ matrix.command }}" | sed 's/[:\";<>|*?\/\\ \r\n]/-/g')" >> $GITHUB_OUTPUT
@@ -140,7 +119,28 @@ jobs:
             cp ${{ inputs.coverage_config }} .c8rc.workflow.json
           else
             echo "Using default .c8rc.workflow.json"
-            echo '{"temp-directory":"coverage/tmp","reporter":["text","html"],"lines":50,"branches":0,"functions":0,"statements":0}' > .c8rc.workflow.json
+            cat > .c8rc.workflow.json << 'EOF'
+          {
+            "temp-directory": "coverage/tmp",
+            "reporter": ["text", "html"],
+            "lines": 50,
+            "branches": 0,
+            "functions": 0,
+            "statements": 0,
+            "exclude": [
+              "coverage/**",
+              "packages/*/test{,s}/**",
+              "**/*.d.ts",
+              "test{,s}/**",
+              "test{,-*}.js",
+              "**/*{.,-}test.js",
+              "**/__tests__/**",
+              "**/node_modules/**",
+              "**/babel.config.js",
+              "**/*.tsx"
+            ]
+          }
+          EOF
           fi
 
       - name: Download all coverage summaries

--- a/README.md
+++ b/README.md
@@ -216,22 +216,24 @@ This workflow is designed to accommodate different testing needs, offering flexi
 
 ### [NPM Tests](.github/workflows/npm-tests.yml)
 
-Runs specified NPM tests (e.g., unit and integration tests) with optional build and pre-test commands, as well as Docker-based dependency setup.
+Runs specified NPM tests (e.g., unit and integration tests) with optional build and pre-test commands, as well as Docker-based dependency setup. Optionally collects and reports code coverage.
 
 #### Inputs
 
-| Input               | Type   | Description                                                                                                           | Default                             | Required |
-| ------------------- | ------ | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | -------- |
-| env_vars            | string | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                                | false    |
-| npm_build_command   | string | Optional command to build the application before running tests                                                        | `''`                                | false    |
-| pre_test_command    | string | Optional command to execute before the main test command                                                              | `''`                                | false    |
-| docker_compose_file | string | The Docker Compose file to use for setting up dependencies                                                            | `docker-compose.yml`                | false    |
-| npm_version         | string | The node version to use                                                                                               | `'22.x'`                            | false    |
-| tests               | string | JSON array of test commands defined in NPM scripts (e.g., `["test:unit", "test:integration"]`)                        | `["test:unit", "test:integration"]` | false    |
+| Input               | Type    | Description                                                                                                           | Default                             | Required |
+| ------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | -------- |
+| env_vars            | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                                | false    |
+| npm_build_command   | string  | Optional command to build the application before running tests                                                        | `''`                                | false    |
+| pre_test_command    | string  | Optional command to execute before the main test command                                                              | `''`                                | false    |
+| docker_compose_file | string  | The Docker Compose file to use for setting up dependencies                                                            | `docker-compose.yml`                | false    |
+| npm_version         | string  | The node version to use                                                                                               | `'22.x'`                            | false    |
+| tests               | string  | JSON array of test commands defined in NPM scripts (e.g., `["test:unit", "test:integration"]`)                        | `["test:unit", "test:integration"]` | false    |
+| coverage            | boolean | Whether to collect and report code coverage                                                                           | `false`                             | false    |
+| coverage_path       | string  | Path where coverage JSON summaries are stored                                                                         | `coverage/tmp`                      | false    |
 
 #### Workflow Description
 
-This GitHub Actions workflow runs a series of NPM test commands, with each test command running as a separate job in parallel using a matrix strategy.
+This GitHub Actions workflow runs a series of NPM test commands, with each test command running as a separate job in parallel using a matrix strategy. When coverage is enabled, it collects coverage data from all test jobs and logs a full report.
 
 1. **Set Environment Variables**: Parses `env_vars` from JSON and sets them in the workflow environment.
 2. **Node Setup**: Installs the specified Node.js version.
@@ -243,5 +245,7 @@ This GitHub Actions workflow runs a series of NPM test commands, with each test 
 8. **Wait for Initialization**: Adds a delay to ensure all Docker services are ready.
 9. **Pre-Test Command (Optional)**: Runs `pre_test_command` if provided.
 10. **Run Tests**: Executes each command from the `tests` matrix (e.g., `test:unit`, `test:integration`) as defined in the NPM scripts.
+11. **Upload Coverage (Optional)**: If `coverage` is enabled, uploads coverage JSON summaries from each test job.
+12. **Coverage Report (Optional)**: If `coverage` is enabled, a separate job downloads all coverage summaries, generates text and HTML reports using c8, uploads the HTML report as an artifact, and fails if coverage is below configured thresholds.
 
-This workflow provides a flexible testing setup that allows for custom build commands, pre-test commands, and Docker-based dependencies, making it adaptable for various test scenarios.
+This workflow provides a flexible testing setup that allows for custom build commands, pre-test commands, Docker-based dependencies, and optional code coverage reporting, making it adaptable for various test scenarios.

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ This GitHub Actions workflow is tailored for running end-to-end tests within a D
 
 This workflow is designed to accommodate different testing needs, offering flexibility with custom commands and environment-specific configurations for robust E2E testing.
 
-### [NPM Tests](.github/workflows/npm-tests.yml)
+### [NPM Tests](.github/workflows/tests-npm.yml)
 
-Runs specified NPM tests (e.g., unit and integration tests) with optional build and pre-test commands, as well as Docker-based dependency setup. Optionally collects and reports code coverage.
+Runs specified NPM tests (e.g., unit and integration tests) with optional build and pre-test commands, as well as Docker-based dependency setup. Collects and reports code coverage by default, comparing coverage between the current branch and main branch.
 
 #### Inputs
 
@@ -226,26 +226,39 @@ Runs specified NPM tests (e.g., unit and integration tests) with optional build 
 | npm_build_command   | string  | Optional command to build the application before running tests                                                        | `''`                                | false    |
 | pre_test_command    | string  | Optional command to execute before the main test command                                                              | `''`                                | false    |
 | docker_compose_file | string  | The Docker Compose file to use for setting up dependencies                                                            | `docker-compose.yml`                | false    |
-| npm_version         | string  | The node version to use                                                                                               | `'22.x'`                            | false    |
+| node_version        | string  | The node version to use                                                                                               | `'22.x'`                            | false    |
 | tests               | string  | JSON array of test commands defined in NPM scripts (e.g., `["test:unit", "test:integration"]`)                        | `["test:unit", "test:integration"]` | false    |
-| coverage            | boolean | Whether to collect and report code coverage                                                                           | `false`                             | false    |
-| coverage_path       | string  | Path where coverage JSON summaries are stored                                                                         | `coverage/tmp`                      | false    |
+| coverage            | boolean | Whether to collect and report code coverage                                                                           | `true`                              | false    |
+| coverage_config     | string  | Path to a custom c8 configuration file                                                                                | `''`                                | false    |
 
 #### Workflow Description
 
-This GitHub Actions workflow runs a series of NPM test commands, with each test command running as a separate job in parallel using a matrix strategy. When coverage is enabled, it collects coverage data from all test jobs and logs a full report.
+This GitHub Actions workflow runs a series of NPM test commands in a matrix strategy, testing both the current branch and main branch for coverage comparison. Each test command runs as a separate matrix job. When coverage is enabled, it collects coverage data from all test jobs and generates a comprehensive comparison report.
+
+**Tests Job:**
 
 1. **Set Environment Variables**: Parses `env_vars` from JSON and sets them in the workflow environment.
 2. **Node Setup**: Installs the specified Node.js version.
 3. **Node Modules Caching**: Caches `node_modules` based on `package-lock.json` for faster dependency installation.
 4. **Install Packages**: Installs project dependencies using `npm ci`.
-5. **Build Step (Optional)**: Executes `npm_build_command` if it is provided.
-6. **Environment File Creation**: Creates a `.env` file for environment configuration.
-7. **Setup Docker Dependencies**: Brings up services defined in the specified Docker Compose file to support test dependencies.
-8. **Wait for Initialization**: Adds a delay to ensure all Docker services are ready.
-9. **Pre-Test Command (Optional)**: Runs `pre_test_command` if provided.
-10. **Run Tests**: Executes each command from the `tests` matrix (e.g., `test:unit`, `test:integration`) as defined in the NPM scripts.
-11. **Upload Coverage (Optional)**: If `coverage` is enabled, uploads coverage JSON summaries from each test job.
-12. **Coverage Report (Optional)**: If `coverage` is enabled, a separate job downloads all coverage summaries, generates text and HTML reports using c8, uploads the HTML report as an artifact, and fails if coverage is below configured thresholds.
+5. **Get Coverage Temp Directory**: Determines the coverage temporary directory from the provided config file or uses the default `coverage/tmp`.
+6. **Build Step (Optional)**: Executes `npm_build_command` if it is provided.
+7. **Environment File Creation**: Creates a `.env` file for environment configuration.
+8. **Setup Docker Dependencies**: Brings up services defined in the specified Docker Compose file to support test dependencies.
+9. **Wait for Initialization**: Adds a delay to ensure all Docker services are ready.
+10. **Pre-Test Command (Optional)**: Runs `pre_test_command` if provided.
+11. **Run Tests**: Executes each test command using c8 for coverage collection (e.g., `npx c8 npm run test:unit`).
+12. **Upload Coverage**: If `coverage` is enabled, uploads coverage data from each test job, tagged by branch and test command.
 
-This workflow provides a flexible testing setup that allows for custom build commands, pre-test commands, Docker-based dependencies, and optional code coverage reporting, making it adaptable for various test scenarios.
+**Coverage Job:**
+
+1. **Setup c8 Config**: Creates or copies a c8 configuration file. Uses the provided `coverage_config` if specified, otherwise creates a default configuration.
+2. **Download Coverage Artifacts**: Downloads coverage summaries from both the current branch and main branch test jobs.
+3. **Generate Reports**: Creates HTML, JSON summary, and JSON reports for the current branch coverage.
+4. **Generate Main Branch Reports**: Creates JSON summary and JSON reports for the main branch coverage in a separate directory.
+5. **Setup Vite Config**: Checks for an existing vite/vitest config file, creating a minimal one if none exists to prevent warnings from the coverage report action.
+6. **Pretty Coverage Summary**: Uses `davelosert/vitest-coverage-report-action` to generate a formatted coverage report with trend indicators comparing current branch to main.
+7. **Upload HTML Report**: Saves the comprehensive HTML coverage report as an artifact.
+8. **Fail if Under Thresholds**: Runs c8's threshold check, failing the workflow if coverage is below configured thresholds.
+
+This workflow provides a comprehensive testing and coverage solution with branch comparison, custom build commands, Docker-based dependencies, and detailed coverage reporting including trend analysis.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ This GitHub Actions workflow runs a series of NPM test commands in a matrix stra
 4. **Generate Main Branch Reports**: Creates JSON summary and JSON reports for the main branch coverage in a separate directory.
 5. **Setup Vite Config**: Checks for an existing vite/vitest config file, creating a minimal one if none exists to prevent warnings from the coverage report action.
 6. **Pretty Coverage Summary**: Uses `davelosert/vitest-coverage-report-action` to generate a formatted coverage report with trend indicators comparing current branch to main.
-7. **Upload HTML Report**: Saves the comprehensive HTML coverage report as an artifact.
+7. **Upload Reports for Current Branch**: Saves current branch coverage reports as an artifact.
 8. **Fail if Under Thresholds**: Runs c8's threshold check, failing the workflow if coverage is below configured thresholds.
 
 This workflow provides a comprehensive testing and coverage solution with branch comparison, custom build commands, Docker-based dependencies, and detailed coverage reporting including trend analysis.


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

https://digicatapult.atlassian.net/browse/ENG-196

## High level description

Example of passing https://github.com/digicatapult/dtdl-visualisation-tool/actions/runs/19105214475

Coverage report with c8 turned ON by default:
- uploads raw coverage of each test run in the matrix on current branch and `main`
- downloads and merges raw outputs into a current branch and `main` report
- logs [pretty text report](https://github.com/digicatapult/dtdl-visualisation-tool/actions/runs/19105214475) (external action). Shows % change from `main` 
- uploads full report artifact for devs that want line by line reporting
- if action is triggered by `on: pull_request` - a comment is posted on the PR too. Subsequent pushes edit the comment rather than spamming new ones.
- fails if coverage is below threshold 
- uses sensible defaults for `include/exclude` and `thresholds`. c8 settings can be set within each repo by supplying path to `.c8rc.json` in the `coverage_config` input.

## Detailed description

Tested against https://github.com/digicatapult/dtdl-visualisation-tool/pull/379


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

**Will turn on coverage reporting in all repos that use the workflow!**

Finding the right default thresholds could be fiddly. Could block legitimate PRs from passing

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
