### PR TITLE
Read permissions for private repos

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,7 +33,8 @@ on:
         required: false
 jobs:
   repo_ids:
-    permissions: {}
+    permissions:
+      contents: read
     name: Repo IDs
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,7 +1,8 @@
 name: Check version
 on:
   workflow_call:
-permissions: {}
+permissions:
+  contents: read
 jobs:
   check-version:
     name: 'Check version'

--- a/.github/workflows/generate-sbom-npm.yml
+++ b/.github/workflows/generate-sbom-npm.yml
@@ -61,7 +61,8 @@ on:
         required: false
       DTRACK_HOSTNAME:
         required: false
-permissions: {}
+permissions:
+  contents: read
 jobs:
   generate-sbom:
     name: "Generate SBOM"

--- a/.github/workflows/scan-secrets.yml
+++ b/.github/workflows/scan-secrets.yml
@@ -22,7 +22,8 @@ on:
         type: string
         default: "--results=verified,unknown"
         description: Extra arguments to be passed to the TruffleHog CLI.
-permissions: {}
+permissions:
+  contents: read
 jobs:
   trufflehog:
     if: ${{ inputs.enable_trufflehog_action == true }}

--- a/.github/workflows/scan-vulns.yml
+++ b/.github/workflows/scan-vulns.yml
@@ -24,6 +24,8 @@ on:
         description: The upload format for the SARIF results - "sarif" uploads the SARIF report directly via CodeQL, "artefact" uploads the report as a PR artefact, and "none" skips the upload step altogether.
 permissions:
   security-events: write
+  contents: read
+  actions: read
 jobs:
   semgrep:
     if: |
@@ -37,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: "3.14"
       - name: Install Semgrep
         run: pip install semgrep
       - name: Semgrep CE scan

--- a/.github/workflows/static-checks-npm.yml
+++ b/.github/workflows/static-checks-npm.yml
@@ -88,6 +88,7 @@ jobs:
   scan-vulns:
     permissions:
       security-events: write
+      contents: read
     if: |
       (inputs.enable_semgrep_action == true) &&
       (github.actor != 'dependabot[bot]')

--- a/.github/workflows/static-checks-npm.yml
+++ b/.github/workflows/static-checks-npm.yml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      actions: read
     if: |
       (inputs.enable_semgrep_action == true) &&
       (github.actor != 'dependabot[bot]')

--- a/.github/workflows/static-checks-npm.yml
+++ b/.github/workflows/static-checks-npm.yml
@@ -40,7 +40,8 @@ on:
         default: "--results=verified,unknown"
 jobs:
   static-checks:
-    permissions: {}
+    permissions:
+      contents: read
     name: Static Analysis Checks - ${{ matrix.command }}
     strategy:
       fail-fast: false
@@ -71,7 +72,8 @@ jobs:
       - name: ${{ matrix.command }}
         run: npm run ${{ matrix.command }}
   scan-secrets:
-    permissions: {}
+    permissions:
+      contents: read
     if: ${{ inputs.enable_trufflehog_action == true }}
     name: Secrets scanning
     runs-on: ubuntu-latest

--- a/.github/workflows/synchronise-trunk-version-npm.yml
+++ b/.github/workflows/synchronise-trunk-version-npm.yml
@@ -15,6 +15,7 @@ jobs:
   find-pull-requests:
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     outputs:
       pr_list: ${{ steps.find.outputs.pr_list }}

--- a/.github/workflows/synchronise-trunk-version-npm.yml
+++ b/.github/workflows/synchronise-trunk-version-npm.yml
@@ -13,7 +13,8 @@ on:
         required: true
 jobs:
   find-pull-requests:
-    permissions: {}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       pr_list: ${{ steps.find.outputs.pr_list }}

--- a/.github/workflows/tests-e2e-npm.yml
+++ b/.github/workflows/tests-e2e-npm.yml
@@ -26,7 +26,8 @@ on:
         required: false
         type: string
         default: "npm run test:e2e"
-permissions: {}
+permissions:
+  contents: read
 jobs:
   e2e-tests:
     name: Run e2e tests

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -36,7 +36,8 @@ on:
         default: ""
 jobs:
   setup:
-    permissions: {}
+    permissions:
+      contents: read
     name: Setup branch matrix
     runs-on: ubuntu-latest
     outputs:
@@ -72,7 +73,8 @@ jobs:
         run: echo "prefix=$(uuidgen)" >> $GITHUB_OUTPUT
 
   tests:
-    permissions: {}
+    permissions:
+      contents: read
     name: Run tests - ${{ matrix.command }} - ${{ matrix.branch }}
     needs: setup
     strategy:

--- a/.github/workflows/tests-npm.yml
+++ b/.github/workflows/tests-npm.yml
@@ -147,6 +147,7 @@ jobs:
 
   coverage:
     permissions:
+      contents: read
       pull-requests: write
     name: Coverage
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Synchronises the version in `package.json` for all open pull-requests that have 
 
 | Access                 | Jobs used                   | Level | Reason                                                                                     |
 | ---------------------- | --------------------------- | ----- | ------------------------------------------------------------------------------------------ |
-| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents and list open pull requests                                     |
+| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                 |
+| `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                  |
 | `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-npm.yml` and POST commits against all open pull requests |
 | `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs     |
 
@@ -459,6 +460,8 @@ Runs scanners to detect bugs, security vulnerabilities, and compliance issues, w
 | Access                   | Jobs used | Level    | Reason                                                     |
 | ------------------------ | --------- | -------- | ---------------------------------------------------------- |
 | `security-events: write` | `semgrep` | Workflow | To POST new code scanning alerts based on the SARIF report |
+| `contents: read`         | `semgrep` | Workflow | To GET repository contents for vulnerability scanning      |
+| `actions: read`          | `semgrep` | Workflow | To GET actions metadata for the scan                       |
 
 #### Workflow Description
 

--- a/README.md
+++ b/README.md
@@ -295,8 +295,10 @@ Performs configurable static analysis checks on an NPM project, such as linting,
 
 | Access                   | Jobs used       | Level | Reason                                                     | Conditions                          |
 | ------------------------ | --------------- | ----- | ---------------------------------------------------------- | ----------------------------------- |
-| `{}` (none)              | `scan-secrets`  | Job   | To implement minimal permissions                           | N/A                                 |
-| `{}` (none)              | `static-checks` | Job   | To implement minimal permissions                           | N/A                                 |
+| `contents: read`         | `scan-secrets`  | Job   | To GET repository contents and history for secret scanning | N/A                                 |
+| `contents: read`         | `static-checks` | Job   | To GET repository contents for static analysis             | N/A                                 |
+| `contents: read`         | `scan-vulns`    | Job   | To GET repository contents for vulnerability scanning      | N/A                                 |
+| `actions: read`          | `scan-vulns`    | Job   | To GET actions metadata for the scan                       | N/A                                 |
 | `security-events: write` | `scan-vulns`    | Job   | To POST new code scanning alerts based on the SARIF report | `inputs.semgrep_upload_type: sarif` |
 
 #### Workflow Description
@@ -375,6 +377,7 @@ Runs specified NPM tests (e.g., unit and integration tests) with optional build 
 | ---------------------- | ---------- | ----- | --------------------------------------------------------------------------- | ----------------- |
 | `contents: read`       | `setup`    | Job   | To GET repository contents and determine branch information                 | N/A               |
 | `contents: read`       | `tests`    | Job   | To GET repository contents and checkout different branches for testing      | N/A               |
+| `contents: read`       | `coverage` | Job   | To GET repository coverage config                                           | N/A               |
 | `pull-requests: write` | `coverage` | Job   | To always POST coverage reports as comments for public/private repositories | `inputs.coverage` |
 
 #### Workflow Description

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This workflow also requires two secrets in order to run:
 | `bot-id`  | Id of the `Github App` to use when committing version updates |
 | `bot-key` | Private Key for the `Github App`                              |
 
-
 ### [Synchronise all PR versions](.github/workflows/synchronise-trunk-version-npm.yml) ([examples](examples/synchronise-trunk-version.md))
 
 Synchronises the version in `package.json` for all open pull-requests that have one of the version labels: [`v:major`, `v:minor`, `v:patch`]. This workflow finds all PRs with these labels and calls the Synchronise PR Version workflow for each one. It's useful after the trunk branch version changes to ensure all open PRs have the correct calculated versions. Like the single PR workflow, it removes the `v:stale` label and commits corrections as needed.
@@ -48,7 +47,7 @@ Synchronises the version in `package.json` for all open pull-requests that have 
 
 | Access                 | Jobs used                   | Level | Reason                                                                                     |
 | ---------------------- | --------------------------- | ----- | ------------------------------------------------------------------------------------------ |
-| `{}` (none)            | `find-pull-requests`        | Job   | To implement minimal permissions                                                           |
+| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents and list open pull requests                                     |
 | `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-npm.yml` and POST commits against all open pull requests |
 | `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs     |
 
@@ -60,7 +59,6 @@ This workflow also requires two secrets in order to run:
 | --------- | ------------------------------------------------------------- |
 | `bot-id`  | Id of the `Github App` to use when committing version updates |
 | `bot-key` | Private Key for the `Github App`                              |
-
 
 ### [Build Docker](.github/workflows/build-docker.yml) ([examples](examples/build-docker.md))
 
@@ -80,7 +78,7 @@ Builds a Docker container and optionally pushes it to GitHub Container Registry 
 #### Permissions
 
 > [!IMPORTANT]
-> Nested jobs that may or may not run still require that the __caller__ workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
+> Nested jobs that may or may not run still require that the **caller** workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
 
 | Access                   | Jobs used      | Level | Reason                                                                   | Conditions                                 |
 | ------------------------ | -------------- | ----- | ------------------------------------------------------------------------ | ------------------------------------------ |
@@ -123,7 +121,6 @@ For all images, the workflow adds OCI-compliant metadata labels to enrich the im
 
 This workflow is versatile, offering a full pipeline for Docker image creation and optional registry publishing, adapting to a range of requirements from simple builds to multi-platform, multi-registry deployments.
 
-
 ### [Check Version](.github/workflows/check-version.yml) ([examples](examples/check-version.md))
 
 Determines the versioning information of the repository, setting output values related to version, release type, and build date. This workflow is typically used as a prerequisite step in other workflows that need version information for tagging, releasing, or publishing. It detects if the current commit represents a new version by comparing the `package.json` version against existing git tags, determines if the version follows pre-release naming conventions (e.g., contains alpha, beta, rc), and captures the build timestamp.
@@ -139,14 +136,13 @@ Determines the versioning information of the repository, setting output values r
 
 #### Permissions
 
-| Access      | Jobs used       | Level    | Reason                           |
-| ----------- | --------------- | -------- | -------------------------------- |
-| `{}` (none) | `check-version` | Workflow | To implement minimal permissions |
+| Access           | Jobs used       | Level    | Reason                                               |
+| ---------------- | --------------- | -------- | ---------------------------------------------------- |
+| `contents: read` | `check-version` | Workflow | To GET repository contents and version from git tags |
 
 #### Workflow Description
 
 This GitHub Actions workflow verifies and checks the versioning details of the repository. It uses the `digicatapult/check-version` action to assess the version information, outputting details such as whether it’s a new version, the version string, if it's a pre-release, and the build date. These outputs can be used by subsequent jobs to conditionally perform tasks based on the versioning state.
-
 
 ### [Release Github](.github/workflows/release-github.yml) ([examples](examples/release-github.md))
 
@@ -162,7 +158,7 @@ Automates the release process on GitHub, creating a versioned release based on t
 #### Permissions
 
 > [!IMPORTANT]
-> Nested jobs that may or may not run still require that the __caller__ workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
+> Nested jobs that may or may not run still require that the **caller** workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
 
 | Access                | Jobs used | Level    | Reason                                                                                        | Conditions        |
 | --------------------- | --------- | -------- | --------------------------------------------------------------------------------------------- | ----------------- |
@@ -180,7 +176,6 @@ This GitHub Actions workflow creates a new release on GitHub. It uses the `digic
 5. **Build Latest Release**: Updates the `latest` tag to point to the newly created release.
 
 This workflow helps streamline the release process by automating version checks and tagging, making it easy to manage versioned releases and update the latest release reference.
-
 
 ### [Release Module NPM](.github/workflows/release-module-npm.yml) ([examples](examples/release-module.md))
 
@@ -223,7 +218,6 @@ This GitHub Actions workflow publishes an NPM package, optionally building it be
 6. **Publish to NPM**: Publishes the package to the specified registry with the given access level, using the provided authentication token.
 
 This workflow simplifies the process of publishing NPM packages by handling environment setup, versioning, and publication in a single automated sequence.
-
 
 ### [NPM Generate SBOM](.github/workflows/generate-sbom-npm.yml) ([examples](examples/generate-sbom.md))
 
@@ -276,7 +270,6 @@ This GitHub Actions workflow generates an SBOM for an NPM project. It allows fle
 6. **Upload Artifact**: Optionally uploads the generated SBOM file as a workflow artifact.
 7. **Upload SBOM to Dependency Track**: Optionally uploads the CycloneDX SBOM to a DT server. Docker Scout SBOMs are currently incompatible with DT due to inaccuracies in the CycloneDX spec implementation; CycloneDX-NPM is a more faithful implementation. To upload successfully, the step must have a DT hostname via the `DTRACK_HOSTNAME` secret and an API key (`DTRACK_APIKEY`) with both the `BOM_UPLOAD` and `PROJECT_CREATION_UPLOAD` permissions.
 
-
 ### [NPM Static Checks](.github/workflows/static-checks-npm.yml) ([examples](examples/static-checks.md))
 
 Performs configurable static analysis checks on an NPM project, such as linting, dependency checking, XSS scanning, and additional checks, based on the specified commands.
@@ -298,7 +291,7 @@ Performs configurable static analysis checks on an NPM project, such as linting,
 #### Permissions
 
 > [!IMPORTANT]
-> Nested jobs that may or may not run still require that the __caller__ workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
+> Nested jobs that may or may not run still require that the **caller** workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
 
 | Access                   | Jobs used       | Level | Reason                                                     | Conditions                          |
 | ------------------------ | --------------- | ----- | ---------------------------------------------------------- | ----------------------------------- |
@@ -320,8 +313,7 @@ This GitHub Actions workflow runs a series of static checks on an NPM project ba
 
 This flexible workflow enables dynamic static analysis checks to maintain code quality, making it adaptable to different project requirements.
 
-
-### [NPM E2E Tests](.github/workflows/tests-e2e-npm.yml)  ([examples](examples/tests-e2e.md))
+### [NPM E2E Tests](.github/workflows/tests-e2e-npm.yml) ([examples](examples/tests-e2e.md))
 
 Executes end-to-end (E2E) tests for an NPM project using Docker Compose, supporting optional build commands and project-specific configurations.
 
@@ -357,33 +349,32 @@ This GitHub Actions workflow is tailored for running end-to-end tests within a D
 
 This workflow is designed to accommodate different testing needs, offering flexibility with custom commands and environment-specific configurations for robust E2E testing.
 
-
-### [NPM Tests](.github/workflows/tests-npm.yml)  ([examples](examples/tests.md))
+### [NPM Tests](.github/workflows/tests-npm.yml) ([examples](examples/tests.md))
 
 Runs specified NPM tests (e.g., unit and integration tests) with optional build and pre-test commands, as well as Docker-based dependency setup. Collects and reports code coverage by default, comparing coverage between the current branch and main branch.
 
 #### Inputs
 
-| Input                | Type    | Description                                                                                                           | Default                                     | Required |
-| -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | -------- |
-| env_vars             | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                                        | false    |
-| npm_build_command    | string  | Optional command to build the application before running tests                                                        | `""`                                        | false    |
-| pre_test_command     | string  | Optional command to execute before the main test command                                                              | `""`                                        | false    |
-| docker_compose_file  | string  | The Docker Compose file to use for setting up dependencies                                                            | `docker-compose.yml`                        | false    |
-| node_version         | string  | The node version to use                                                                                               | `24.x`                                      | false    |
-| tests                | string  | JSON array of test commands defined in NPM scripts (e.g., `["test:unit", "test:integration"]`)                        | `["test:unit","test:integration"]`          | false    |
-| coverage             | boolean | Whether to collect and report code coverage                                                                           | `true`                                      | false    |
-| coverage_config_json | string  |  Path to a custom c8 configuration JSON file                                                                          | `""`                                        | false    |
+| Input                | Type    | Description                                                                                                           | Default                            | Required |
+| -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
+| env_vars             | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                               | false    |
+| npm_build_command    | string  | Optional command to build the application before running tests                                                        | `""`                               | false    |
+| pre_test_command     | string  | Optional command to execute before the main test command                                                              | `""`                               | false    |
+| docker_compose_file  | string  | The Docker Compose file to use for setting up dependencies                                                            | `docker-compose.yml`               | false    |
+| node_version         | string  | The node version to use                                                                                               | `24.x`                             | false    |
+| tests                | string  | JSON array of test commands defined in NPM scripts (e.g., `["test:unit", "test:integration"]`)                        | `["test:unit","test:integration"]` | false    |
+| coverage             | boolean | Whether to collect and report code coverage                                                                           | `true`                             | false    |
+| coverage_config_json | string  | Path to a custom c8 configuration JSON file                                                                           | `""`                               | false    |
 
 #### Permissions
 
 > [!IMPORTANT]
-> Nested jobs that may or may not run still require that the __caller__ workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
+> Nested jobs that may or may not run still require that the **caller** workflow set all of the permissions referenced in the callee. Conditions don't affect whether the permissions block should be included, but rather when and where access is gained.
 
 | Access                 | Jobs used  | Level | Reason                                                                      | Conditions        |
 | ---------------------- | ---------- | ----- | --------------------------------------------------------------------------- | ----------------- |
-| `{}` (none)            | `setup`    | Job   | To implement minimal permissions                                            | N/A               |
-| `{}` (none)            | `tests`    | Job   | To implement minimal permissions                                            | N/A               |
+| `contents: read`       | `setup`    | Job   | To GET repository contents and determine branch information                 | N/A               |
+| `contents: read`       | `tests`    | Job   | To GET repository contents and checkout different branches for testing      | N/A               |
 | `pull-requests: write` | `coverage` | Job   | To always POST coverage reports as comments for public/private repositories | `inputs.coverage` |
 
 #### Workflow Description
@@ -418,7 +409,6 @@ This GitHub Actions workflow runs a series of NPM test commands in a matrix stra
 
 This workflow provides a comprehensive testing and coverage solution with branch comparison, custom build commands, Docker-based dependencies, and detailed coverage reporting including trend analysis.
 
-
 ### [Scan Secrets](.github/workflows/scan-secrets.yml) ([examples](examples/scan-secrets.md))
 
 Runs scanners to detect the exposure of secrets, with the option to add in extra arguments to exclude directories, fail on detection, or output the results in JSON format.
@@ -434,9 +424,9 @@ Runs scanners to detect the exposure of secrets, with the option to add in extra
 
 #### Permissions
 
-| Access      | Jobs used    | Level    | Reason                           |
-| ----------- | ------------ | -------- | -------------------------------- |
-| `{}` (none) | `trufflehog` | Workflow | To implement minimal permissions |
+| Access           | Jobs used    | Level    | Reason                                                     |
+| ---------------- | ------------ | -------- | ---------------------------------------------------------- |
+| `contents: read` | `trufflehog` | Workflow | To GET repository contents and history for secret scanning |
 
 #### Workflow Description
 
@@ -446,7 +436,6 @@ This GitHub Actions workflow runs TruffleHog scans.
 2. **TruffleHog PR Scan**: Execute the TruffleHog scan of the PR, checking for verified and unverified secrets.
 
 This workflow can be complemented with the complete list of TruffleHog arguments, found in that project's [repository](https://github.com/trufflesecurity/trufflehog/?tab=readme-ov-file#memo-usage).
-
 
 ### [Scan Vulnerabilities](.github/workflows/scan-vulns.yml) ([examples](examples/scan-vulns.md))
 

--- a/examples/build-docker.md
+++ b/examples/build-docker.md
@@ -3,6 +3,7 @@
 ## Using [build-docker.yml](../.github/workflows/build-docker.yml) in callers
 
 Several permissions are needed for the `build-docker` job:
+
 - `contents: read`
 - `packages: write`
 - `security-events: write`
@@ -11,12 +12,9 @@ They should be invoked at the job level. Reading READMEs and LICENSE information
 
 To upload details about any potential security vulnerabilities (CVEs) via GitHub's Code Scanning APIs, the ability to write security events is needed. These alerts are visible within the GitHub repository's Security panel. If GitHub Code Scanning is disabled at the time the workflow is executed, then the step will fail.
 
-By contrast, the `repo-ids` job doesn't require any additional levels of access and should take minimal permissions: `permissions: {}`.
-
-
 ### Explicit permissions with defaults
 
-A very minimal workflow will build an image without pushing it to a container registry. This is useful for testing that the image builds successfully. Callers will need to list the permissions for all nested jobs, even if there is only one specific job using them and all others are set to minimal access (`permissions: {}`).
+A very minimal workflow will build an image without pushing it to a container registry. This is useful for testing that the image builds successfully. Callers will need to list the permissions for all nested jobs, even if there is only one specific job using them and all others are set to minimal access (`permissions: { contents: read }`).
 
 ```yaml
 jobs:
@@ -28,7 +26,6 @@ jobs:
       security-events: write
 ```
 
-
 ### Implicit permissions
 
 ```yaml
@@ -36,7 +33,6 @@ jobs:
   build-docker:
     uses: digicatapult/shared-workflows/.github/workflows/build-docker.yml@main
 ```
-
 
 ### Minimal with a registry push
 

--- a/examples/check-version.md
+++ b/examples/check-version.md
@@ -2,9 +2,6 @@
 
 ## Using [check-version.yml](../.github/workflows/check-version.yml) in callers
 
-> [!TIP]
-> For public repos, no extra job/workflow permissions are required by any of the options.
-
 ### Explicit permissions with defaults
 
 A minimal workflow will check the versions for the working branch in `package*.json`, as the default option is to assume NPM as the package manager. Cargo and Poetry are also supported.

--- a/examples/check-version.md
+++ b/examples/check-version.md
@@ -3,8 +3,7 @@
 ## Using [check-version.yml](../.github/workflows/check-version.yml) in callers
 
 > [!TIP]
-> No extra job/workflow permissions are required by any of the options.
-
+> For public repos, no extra job/workflow permissions are required by any of the options.
 
 ### Explicit permissions with defaults
 
@@ -14,9 +13,9 @@ A minimal workflow will check the versions for the working branch in `package*.j
 jobs:
   check-version:
     uses: digicatapult/shared-workflows/.github/workflows/check-version.yml@main
-    permissions: {}
+    permissions:
+      contents: read
 ```
-
 
 ### Implicit permissions
 

--- a/examples/generate-sbom.md
+++ b/examples/generate-sbom.md
@@ -3,8 +3,7 @@
 ## Using [generate-sbom-npm.yml](../.github/workflows/generate-sbom-npm.yml) in callers
 
 > [!TIP]
-> No extra job/workflow permissions are required by any of the options.
-
+> For public repos, no extra job/workflow permissions are required by any of the options.
 
 ### Explicit permissions with defaults
 
@@ -14,9 +13,9 @@ A minimal workflow will create the SBOM against the working branch and upload it
 jobs:
   generate-sbom-npm:
     uses: digicatapult/shared-workflows/.github/workflows/generate-sbom-npm.yml@main
-    permissions: {}
+    permissions:
+      contents: read
 ```
-
 
 ### Implicit permissions
 
@@ -26,7 +25,6 @@ jobs:
     uses: digicatapult/shared-workflows/.github/workflows/generate-sbom-npm.yml@main
 ```
 
-
 ### Error handling
 
 In practice, the CycloneDX tooling will fail on a range of errors, including excessive dependencies. To minimise the time spent debugging this, it's advisable to ignore the errors instead.
@@ -35,11 +33,11 @@ In practice, the CycloneDX tooling will fail on a range of errors, including exc
 jobs:
   generate-sbom-npm:
     uses: digicatapult/shared-workflows/.github/workflows/generate-sbom-npm.yml@main
-    permissions: {}
+    permissions:
+      contents: read
     with:
       additional_args: "--ignore-npm-errors"
 ```
-
 
 ### Minimal using Dependency Track
 
@@ -49,7 +47,8 @@ To invoke the use of Dependency Track as a destination for the SBOMs, it's neces
 jobs:
   generate-sbom-npm:
     uses: digicatapult/shared-workflows/.github/workflows/generate-sbom-npm.yml@main
-    permissions: {}
+    permissions:
+      contents: read
     with:
       additional_args: "--ignore-npm-errors"
       enable_check_version: true

--- a/examples/generate-sbom.md
+++ b/examples/generate-sbom.md
@@ -2,9 +2,6 @@
 
 ## Using [generate-sbom-npm.yml](../.github/workflows/generate-sbom-npm.yml) in callers
 
-> [!TIP]
-> For public repos, no extra job/workflow permissions are required by any of the options.
-
 ### Explicit permissions with defaults
 
 A minimal workflow will create the SBOM against the working branch and upload it as an artifact, potentially for use by other jobs. This won't upload it to a Dependency Track host, however. It can be useful to check for issues with dependencies or the formatting of SBOMs, as the CycloneDX-NPM tool is quite strict.

--- a/examples/scan-secrets.md
+++ b/examples/scan-secrets.md
@@ -2,9 +2,6 @@
 
 ## Using [scan-secrets.yml](../.github/workflows/scan-secrets.yml) in callers
 
-> [!TIP]
-> For public repos, no extra job/workflow permissions are required by any of the options.
-
 ### Explicit permissions with defaults
 
 This call invokes the TruffleHog action, scanning for exposed secrets. TruffleHog merely scans the working branch by default. Its results are printed, rather than uploaded.

--- a/examples/scan-secrets.md
+++ b/examples/scan-secrets.md
@@ -3,8 +3,7 @@
 ## Using [scan-secrets.yml](../.github/workflows/scan-secrets.yml) in callers
 
 > [!TIP]
-> No extra job/workflow permissions are required by any of the options.
-
+> For public repos, no extra job/workflow permissions are required by any of the options.
 
 ### Explicit permissions with defaults
 
@@ -14,9 +13,9 @@ This call invokes the TruffleHog action, scanning for exposed secrets. TruffleHo
 jobs:
   scan-secrets:
     uses: digicatapult/shared-workflows/.github/workflows/scan-secrets.yml@main
-    permissions: {}
+    permissions:
+      contents: read
 ```
-
 
 ### Implicit permissions
 

--- a/examples/scan-vulns.md
+++ b/examples/scan-vulns.md
@@ -2,8 +2,7 @@
 
 ## Using [scan-vulns.yml](../.github/workflows/scan-vulns.yml) in callers
 
-Only the `security-events: write` permission is used and it's invoked at the workflow level for the `semgrep` job.
-
+`security-events: write`, `contents: read`, and `actions: read` permissions are used. They are invoked at the workflow level for the `semgrep` job.
 
 ### Explicit permissions with defaults
 
@@ -15,8 +14,9 @@ jobs:
     uses: digicatapult/shared-workflows/.github/workflows/scan-vulns.yml@main
     permissions:
       security-events: write
+      contents: read
+      actions: read
 ```
-
 
 ### Implicit permissions
 

--- a/examples/static-checks.md
+++ b/examples/static-checks.md
@@ -35,6 +35,7 @@ jobs:
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
     permissions:
+      security-events: write
       contents: read
       actions: read
     with:
@@ -49,6 +50,10 @@ If `inputs.enable_semgrep_action` is changed to `false`, then Semgrep isn't exec
 jobs:
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
     with:
       enable_semgrep_action: false
 ```

--- a/examples/static-checks.md
+++ b/examples/static-checks.md
@@ -4,7 +4,6 @@
 
 The permission `security-events: write` is used in this workflow and it's required at the job level for `scan-vulns`. Neither `static-checks` nor `scan-secrets` require any permissions.
 
-
 ### Explicit permissions with defaults
 
 As part of this workflow, Semgrep creates a SARIF report that captures any vulnerabilities found. If the repository doesn't have GitHub Code Scanning enabled beforehand, then the required endpoints to POST the report to can't be reached and the workflow itself will likely fail at that point.
@@ -15,8 +14,9 @@ jobs:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
     permissions:
       security-events: write
+      contents: read
+      actions: read
 ```
-
 
 ### Implicit permissions with defaults
 
@@ -25,7 +25,6 @@ jobs:
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
 ```
-
 
 ### Minimal with PR artefacts
 
@@ -36,11 +35,11 @@ jobs:
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
     permissions:
-      security-events: write
+      contents: read
+      actions: read
     with:
       semgrep_upload_type: "artefact"
 ```
-
 
 ### Minimal without Semgrep checks
 
@@ -50,8 +49,6 @@ If `inputs.enable_semgrep_action` is changed to `false`, then Semgrep isn't exec
 jobs:
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
-    permissions:
-      security-events: write
     with:
       enable_semgrep_action: false
 ```

--- a/examples/static-checks.md
+++ b/examples/static-checks.md
@@ -2,7 +2,7 @@
 
 ## Using [static-checks-npm.yml](../.github/workflows/static-checks-npm.yml) in callers
 
-The permission `security-events: write` is used in this workflow and it's required at the job level for `scan-vulns`. Neither `static-checks` nor `scan-secrets` require any permissions.
+`static-checks` and `scan-secrets` require `contents: read` permissions, and `scan-vulns` requires `security-events: write`, `contents: read`, and `actions: read`.
 
 ### Explicit permissions with defaults
 

--- a/examples/synchronise-trunk-version.md
+++ b/examples/synchronise-trunk-version.md
@@ -2,12 +2,17 @@
 
 ## Using [synchronise-trunk-version-npm.yml](../.github/workflows/synchronise-trunk-version-npm.yml) in callers
 
-Several permissions are assumed by the job `synchronise-pull-requests`:
+The following permissions are assumed by the job `find-pull-requests`:
+
+- contents: read
+- pull-requests: read
+
+The following permissions are assumed by the job `synchronise-pull-requests`:
+
 - contents: write
 - pull-requests: write
 
 Both permissions are required by the upstream [synchronise-pr-version-npm.yml](../.github/workflows/synchronise-pr-version-npm.yml) workflow.
-
 
 ### Explicit permissions with defaults
 
@@ -24,7 +29,6 @@ jobs:
       bot-id: ${{ secrets.BOT_ID }}
       bot-key: ${{ secrets.BOT_KEY }}
 ```
-
 
 ### Implicit permissions
 

--- a/examples/tests-e2e.md
+++ b/examples/tests-e2e.md
@@ -2,9 +2,6 @@
 
 ## Using [tests-e2e-npm.yml](../.github/workflows/tests-e2e-npm.yml) in callers
 
-> [!TIP]
-> For public repos, no extra job/workflow permissions are required by any of the options.
-
 ### Explicit permissions with defaults
 
 This caller invokes the default end-to-end test scripts, as defined in the `package.json` file for the NPM project.

--- a/examples/tests-e2e.md
+++ b/examples/tests-e2e.md
@@ -3,8 +3,7 @@
 ## Using [tests-e2e-npm.yml](../.github/workflows/tests-e2e-npm.yml) in callers
 
 > [!TIP]
-> No extra job/workflow permissions are required by any of the options.
-
+> For public repos, no extra job/workflow permissions are required by any of the options.
 
 ### Explicit permissions with defaults
 
@@ -14,9 +13,9 @@ This caller invokes the default end-to-end test scripts, as defined in the `pack
 jobs:
   tests-e2e-npm:
     uses: digicatapult/shared-workflows/.github/workflows/tests-e2e-npm.yml@main
-    permissions: {}
+    permissions:
+      contents: read
 ```
-
 
 ### Implicit permissions
 
@@ -26,7 +25,6 @@ jobs:
     uses: digicatapult/shared-workflows/.github/workflows/tests-e2e-npm.yml@main
 ```
 
-
 ### Minimal with secret inheritance
 
 If the end-to-end tests need to handle tokens or credentials from an earlier workflow, then they can inherit them with the following example:
@@ -35,6 +33,7 @@ If the end-to-end tests need to handle tokens or credentials from an earlier wor
 jobs:
   tests-e2e-npm:
     uses: digicatapult/shared-workflows/.github/workflows/tests-e2e-npm.yml@main
-    permissions: {}
+    permissions:
+      contents: read
     secrets: inherit
 ```

--- a/examples/tests.md
+++ b/examples/tests.md
@@ -4,6 +4,8 @@
 
 The permission `pull-requests: write` is assumed at the workflow level the `coverage` job, specifically by the step using `davelosert/vitest-coverage-report-action`. No permissions are required for the `setup` and `tests` jobs.
 
+Permissions `pull-requests: write` and `contents: read` are required by the `coverage` job (specifically by the step using `davelosert/vitest-coverage-report-action`). `contents: read` is required by the `setup` and `tests` jobs.
+
 ### Explicit permissions with defaults
 
 This caller workflow invokes the default test scripts, as defined in the `package.json` file for the NPM project.

--- a/examples/tests.md
+++ b/examples/tests.md
@@ -4,7 +4,6 @@
 
 The permission `pull-requests: write` is assumed at the workflow level the `coverage` job, specifically by the step using `davelosert/vitest-coverage-report-action`. No permissions are required for the `setup` and `tests` jobs.
 
-
 ### Explicit permissions with defaults
 
 This caller workflow invokes the default test scripts, as defined in the `package.json` file for the NPM project.
@@ -15,8 +14,8 @@ jobs:
     uses: digicatapult/shared-workflows/.github/workflows/tests-npm.yml@main
     permissions:
       pull-requests: write
+      contents: read
 ```
-
 
 ### Implicit permissions
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/SKG-21

## High level description

Add `contents: read` permissions to jobs that read repos. Required for private repos. Previously wasn't required because all repos using shared workflows were public.

## Detailed description

See workflows passing on a private repo using this branch https://github.com/digicatapult/spec-rag-api/pull/1


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

**This will break the action of any repo that's calling a shared workflow and setting explicit permissions without including new ones.**

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
