### PR TITLE
Grant Scout access to the image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -119,7 +119,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Dockerhub Registry
-        if: ${{ inputs.push_dockerhub == true }}
+        if: ${{ inputs.push_ghcr == true || inputs.push_dockerhub == true }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -229,12 +229,6 @@ jobs:
           organization: ${{ needs.repo_ids.outputs.org_name }}
           exit-code: false
           sarif-file: scout.sarif
-      - name: Login to Dockerhub Registry
-        if: ${{ inputs.push_ghcr == true && inputs.push_dockerhub == false }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Generate CVEs with Docker Scout (GHCR only)
         if: ${{ inputs.push_ghcr == true && inputs.push_dockerhub == false }}
         uses: docker/scout-action@v1

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -229,6 +229,12 @@ jobs:
           organization: ${{ needs.repo_ids.outputs.org_name }}
           exit-code: false
           sarif-file: scout.sarif
+      - name: Login to Dockerhub Registry
+        if: ${{ inputs.push_ghcr == true && inputs.push_dockerhub == false }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Generate CVEs with Docker Scout (GHCR only)
         if: ${{ inputs.push_ghcr == true && inputs.push_dockerhub == false }}
         uses: docker/scout-action@v1


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

Scout isn't able to access the image when `inputs.push_dockerhub == false` as it doesn't log in. Logging in just for the CVE checks should resolve the issue.