### PR TITLE
Add parent GUID handling for Dependency-Track

### DIFF
--- a/.github/workflows/generate-sbom-npm.yml
+++ b/.github/workflows/generate-sbom-npm.yml
@@ -66,6 +66,8 @@ on:
         required: false
       DTRACK_HOSTNAME:
         required: false
+      DTRACK_PARENT_GUID:
+        required: false
 jobs:
   generate-sbom:
     uses: ./.github/workflows/generate-sbom.yml
@@ -85,3 +87,4 @@ jobs:
     secrets:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
+      DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -80,6 +80,8 @@ on:
         required: false
       DTRACK_HOSTNAME:
         required: false
+      DTRACK_PARENT_GUID:
+        required: false
 jobs:
   generate-sbom:
     name: "Generate SBOM"
@@ -182,11 +184,24 @@ jobs:
           name: ${{ steps.set-filename.outputs.filename }}
           path: ${{ steps.set-filename.outputs.filename }}
           retention-days: 90
-      - uses: DependencyTrack/gh-upload-sbom@v3
+      - name: Check Dependency-Track project status
+        id: check_dtrack_project_status
+        shell: bash
+        run: |
+          if [ \"$DTRACK_PARENT_GUID\" == \"\" ]; then
+            echo \"dtrack_parent_guid_set=NO\" >> $GITHUB_OUTPUT
+          else
+            echo \"dtrack_parent_guid_set=YES\" >> $GITHUB_OUTPUT
+          fi
+        env:
+          DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}
+      - name: Upload SBOM to Dependency-Track
+        uses: DependencyTrack/gh-upload-sbom@v3
         if: |
           success() &&
           inputs.enable_check_version &&
-          inputs.enable_dtrack_project
+          inputs.enable_dtrack_project &&
+          steps.check_dtrack_project_status.dtrack_parent_guid_set == 'YES'
         with:
           serverhostname: ${{ secrets.DTRACK_HOSTNAME }}
           apikey: ${{ secrets.DTRACK_APIKEY }}
@@ -195,3 +210,4 @@ jobs:
           projecttags: ${{ steps.get-version.outputs.version }}
           bomfilename: ${{ steps.set-filename.outputs.filename }}
           autocreate: true
+          parent: ${{ secrets.DTRACK_PARENT_GUID }}

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -187,11 +187,12 @@ jobs:
       - name: Check Dependency-Track project status
         id: check_dtrack_project_status
         shell: bash
+        if: inputs.enable_dtrack_project
         run: |
-          if [ \"$DTRACK_PARENT_GUID\" == \"\" ]; then
-            echo \"dtrack_parent_guid_set=NO\" >> $GITHUB_OUTPUT
+          if [ -z "$DTRACK_PARENT_GUID" ]; then
+            echo "dtrack_parent_guid_set=NO" >> "$GITHUB_OUTPUT"
           else
-            echo \"dtrack_parent_guid_set=YES\" >> $GITHUB_OUTPUT
+            echo "dtrack_parent_guid_set=YES" >> "$GITHUB_OUTPUT"
           fi
         env:
           DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}
@@ -201,7 +202,7 @@ jobs:
           success() &&
           inputs.enable_check_version &&
           inputs.enable_dtrack_project &&
-          steps.check_dtrack_project_status.dtrack_parent_guid_set == 'YES'
+          steps.check_dtrack_project_status.outputs.dtrack_parent_guid_set == 'YES'
         with:
           serverhostname: ${{ secrets.DTRACK_HOSTNAME }}
           apikey: ${{ secrets.DTRACK_APIKEY }}

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ This GitHub Actions workflow generates an SBOM for a project. It allows flexibil
 4. **Build (Optional)**: Runs a build command if specified, useful for projects that need compilation before SBOM generation.
 5. **Generate SBOM**: Uses the selected tool (`@cyclonedx/cyclonedx-npm` or `@cyclonedx/cdxgen`) to generate the SBOM.
 6. **Upload Artifact**: Optionally uploads the generated SBOM file as a workflow artifact.
-7. **Upload SBOM to Dependency Track**: Optionally uploads the CycloneDX SBOM to a DT server. Docker Scout SBOMs are currently incompatible with DT due to inaccuracies in the CycloneDX spec implementation; CycloneDX-NPM is a more faithful implementation. To upload successfully, the step must have a DT hostname via the `DTRACK_HOSTNAME` secret and an API key (`DTRACK_APIKEY`) with both the `BOM_UPLOAD` and `PROJECT_CREATION_UPLOAD` permissions.
+7. **Upload SBOM to Dependency Track**: Optionally uploads the CycloneDX SBOM to a DT server. Docker Scout SBOMs are currently incompatible with DT due to inaccuracies in the CycloneDX spec implementation; CycloneDX-NPM is a more faithful implementation. To upload successfully, the step must have a DT hostname via the `DTRACK_HOSTNAME` secret, a parent project GUID (`DTRACK_PARENT_GUID`), and an API key (`DTRACK_APIKEY`) with both the `BOM_UPLOAD` and `PROJECT_CREATION_UPLOAD` permissions.
 
 ### [Poetry Static checks](.github/workflows/static-checks-poetry.yml) ([examples](examples/static-checks-poetry.md))
 

--- a/README.md
+++ b/README.md
@@ -256,10 +256,11 @@ For backwards compatibility, the legacy filename [.github/workflows/generate-sbo
 
 #### Secrets
 
-| Secret            | Description                                                                                                                                     |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DTRACK_APIKEY`   | The Dependency Track API key; requires both the `BOM_UPLOAD` and `PROJECT_CREATION_UPLOAD` permissions                                          |
-| `DTRACK_HOSTNAME` | The hostname of the Dependency Track server; the HTTP schema is set separately with the inputs `protocol` (default: `https`) and `port` (`443`) |
+| Secret               | Description                                                                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DTRACK_APIKEY`      | The Dependency Track API key; requires both the `BOM_UPLOAD` and `PROJECT_CREATION_UPLOAD` permissions                                          |
+| `DTRACK_HOSTNAME`    | The hostname of the Dependency Track server; the HTTP schema is set separately with the inputs `protocol` (default: `https`) and `port` (`443`) |
+| `DTRACK_PARENT_GUID` | The project GUID for the parent project within Dependency Track, typically named after the project repository and tagged with 'parent'          |
 
 #### Outputs
 

--- a/examples/generate-sbom.md
+++ b/examples/generate-sbom.md
@@ -33,7 +33,7 @@ jobs:
 
 ### Minimal using Dependency Track
 
-To invoke the use of Dependency Track as a destination for the SBOMs, it's necessary to provide the secrets `DTRACK_APIKEY` and `DTRACK_HOSTNAME` and the ensure that `inputs.enable_check_version` and `inputs.enable_dtrack_project` both resolve to `true`.
+To invoke the use of Dependency Track as a destination for the SBOMs, it's necessary to provide the secrets `DTRACK_APIKEY`, `DTRACK_HOSTNAME`, `DTRACK_PARENT_GUID`, and ensure that `inputs.enable_check_version` and `inputs.enable_dtrack_project` both resolve to `true`.
 
 ```yaml
 jobs:

--- a/examples/generate-sbom.md
+++ b/examples/generate-sbom.md
@@ -48,6 +48,7 @@ jobs:
     secrets:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
+      DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}
 
 ```
 
@@ -73,4 +74,5 @@ jobs:
     secrets:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
+      DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}
 ```


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## High level description

Dependency-Track management is challenging with projects that return a lot of PRs. One way to better manage this within the GUI is through the use of parents, where some project is designated as the parent node and all other versioned entries for that project or repository sit underneath. This clusters projects together. To expose the parent GUID however, one would need an API call; there's no easy method to retrieve an existing GUID except to add it as a secret manually. If there isn't yet a parent upstream, then it'd be preferred to re-run the job once it exists and has been added as a secret.