### PR TITLE
docs: document Poetry workflows, add contents page, and standardise all workflow tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 Shared github workflows created by the `digicatapult` organisation.
 
+## Contents
+
+**Version synchronisation**
+
+- [Synchronise PR Version](#synchronise-pr-version-examples)
+- [Synchronise PR Version (Poetry)](#synchronise-pr-version-poetry-examples)
+- [Synchronise all PR versions](#synchronise-all-pr-versions-examples)
+- [Synchronise all PR versions (Poetry)](#synchronise-all-pr-versions-poetry-examples)
+
+**Build & release**
+
+- [Build Docker](#build-docker-examples)
+- [Check Version](#check-version-examples)
+- [Release Github](#release-github-examples)
+- [Release Module NPM](#release-module-npm-examples)
+
+**Testing & quality**
+
+- [Poetry Static checks](#poetry-static-checks-examples)
+- [Poetry Tests](#poetry-tests-examples)
+- [Poetry E2E tests](#poetry-e2e-tests-examples)
+- [NPM Static Checks](#npm-static-checks-examples)
+- [NPM E2E Tests](#npm-e2e-tests-examples)
+- [NPM Tests](#npm-tests-examples)
+
+**Security & analysis**
+
+- [Generate SBOM](#generate-sbom-examples)
+- [Scan Secrets](#scan-secrets-examples)
+- [Scan Vulnerabilities](#scan-vulnerabilities-examples)
+
 ## Workflows
 
 > [!IMPORTANT]
@@ -40,6 +71,29 @@ This workflow also requires two secrets in order to run:
 
 Synchronises the version in a `pyproject.toml` on a pull-request branch in relation to a trunk branch based on the presence of one of three labels: [`v:major`, `v:minor`, `v:patch`]. Like the NPM variant, it calculates the next version by incrementing the trunk branch version and commits corrections as needed.
 
+#### Inputs
+
+| Input          | Type     | Description                             | Default |
+| -------------- | -------- | --------------------------------------- | ------- |
+| `pr-number`    | `number` | The PR to run this workflow for         |         |
+| `trunk-branch` | `string` | The trunk branch to synchronise against | `main`  |
+
+#### Permissions
+
+| Access                 | Jobs used             | Level    | Reason                                                                            |
+| ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- |
+| `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` |
+| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                      |
+
+#### Secrets
+
+This workflow also requires two secrets in order to run:
+
+| Secret    | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `bot-id`  | Id of the `Github App` to use when committing version updates |
+| `bot-key` | Private Key for the `Github App`                              |
+
 ### [Synchronise all PR versions](.github/workflows/synchronise-trunk-version-npm.yml) ([examples](examples/synchronise-trunk-version.md))
 
 Synchronises the version in `package.json` for all open pull-requests that have one of the version labels: [`v:major`, `v:minor`, `v:patch`]. This workflow finds all PRs with these labels and calls the Synchronise PR Version workflow for each one. It's useful after the trunk branch version changes to ensure all open PRs have the correct calculated versions. Like the single PR workflow, it removes the `v:stale` label and commits corrections as needed.
@@ -70,7 +124,31 @@ This workflow also requires two secrets in order to run:
 
 ### [Synchronise all PR versions (Poetry)](.github/workflows/synchronise-trunk-version-poetry.yml) ([examples](examples/synchronise-trunk-version-poetry.md))
 
-Synchronises the version in `pyproject.toml` for all open pull requests that have one of the version labels: [`v:major`, `v:minor`, `v:patch`].
+Synchronises the version in `pyproject.toml` for all open pull requests that have one of the version labels: [`v:major`, `v:minor`, `v:patch`]. This workflow finds all PRs with these labels and calls the Synchronise PR Version (Poetry) workflow for each one. It removes the `v:stale` label and commits corrections as needed.
+
+#### Inputs
+
+| Input          | Type     | Description                             | Default |
+| -------------- | -------- | --------------------------------------- | ------- |
+| `trunk-branch` | `string` | The trunk branch to synchronise against | `main`  |
+
+#### Permissions
+
+| Access                 | Jobs used                   | Level | Reason                                                                                        |
+| ---------------------- | --------------------------- | ----- | --------------------------------------------------------------------------------------------- |
+| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                    |
+| `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                     |
+| `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-poetry.yml` and POST commits against all open pull requests |
+| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs        |
+
+#### Secrets
+
+This workflow also requires two secrets in order to run:
+
+| Secret    | Description                                                   |
+| --------- | ------------------------------------------------------------- |
+| `bot-id`  | Id of the `Github App` to use when committing version updates |
+| `bot-key` | Private Key for the `Github App`                              |
 
 ### [Build Docker](.github/workflows/build-docker.yml) ([examples](examples/build-docker.md))
 
@@ -239,13 +317,17 @@ For backwards compatibility, the legacy filename [.github/workflows/generate-sbo
 | dtrack_project_name   | string  | A project name to use within Dependency Track                                                                                             | `${{ github.event.repository.name }}` | false    |
 | enable_check_version  | boolean | An option to enable the use of the digicatapult/check-version action                                                                      | `false`                               | false    |
 | enable_dtrack_project | boolean | An option to enable the use of Dependency Track                                                                                           | `false`                               | false    |
+| package_manager       | string  | Package manager for version detection. Options: `npm`, `poetry`                                                                          | `npm`                                 | false    |
 | env_vars              | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                  | false    |
 | node_version          | string  | The node version to use                                                                                                                   | `24.x`                                | false    |
+| python_version        | string  | The Python version to use (for Poetry / `cdxgen` SBOMs)                                                                                    | `3.14`                                | false    |
 | sbom_tool             | string  | SBOM generation tool to use. Options: `@cyclonedx/cyclonedx-npm`, `@cyclonedx/cdxgen`                                                     | `@cyclonedx/cyclonedx-npm`            | false    |
 | sbom_format           | string  | SBOM output format. Options: `json`, `xml`                                                                                                | `json`                                | false    |
 | sbom_output_file      | string  | Custom output filename. Defaults to `{repo-name}.cdx.{format}`                                                                            | `""`                                  | false    |
 | npm_build_command     | string  | Optional build command to run before generating SBOM                                                                                      | `""`                                  | false    |
 | additional_args       | string  | Additional arguments to pass to the SBOM generation tool                                                                                  | `""`                                  | false    |
+| install_python_deps   | boolean | Install Python dependencies before SBOM generation                                                                                       | `false`                               | false    |
+| python_install_command | string | Optional custom command to install Python dependencies                                                                                   | `""`                                  | false    |
 | upload_artifact       | boolean | Whether to upload the SBOM as a workflow artifact                                                                                         | `true`                                | false    |
 
 #### Permissions
@@ -282,15 +364,115 @@ This GitHub Actions workflow generates an SBOM for a project. It allows flexibil
 
 ### [Poetry Static checks](.github/workflows/static-checks-poetry.yml) ([examples](examples/static-checks-poetry.md))
 
-Runs static analysis for Poetry projects (default matrix includes `pylint`, `black`, `ruff`, `mypy`, and `bandit`).
+Runs static analysis for Poetry projects (default matrix includes `pylint`, `black`, `ruff`, `mypy`, and `bandit`). Each command runs as a separate matrix job so a single failing check does not interrupt the others. Optional TruffleHog (secrets) and Semgrep CE (vulnerabilities) scans can be enabled alongside the static analysis matrix.
+
+#### Inputs
+
+| Input                    | Type      | Description                                                                                                                               | Default                                                                  | Required |
+| ------------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------- |
+| enable_semgrep_action    | `boolean` | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | `true`                                                                   | false    |
+| enable_trufflehog_action | `boolean` | An option to enable a TruffleHog GitHub Action, scanning for exposed secrets                                                              | `false`                                                                  | false    |
+| env_vars                 | `string`  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                                                     | false    |
+| python_version           | `string`  | The Python version to use                                                                                                                 | `3.14`                                                                   | false    |
+| working_directory        | `string`  | The working directory to run the checks from                                                                                              | `.`                                                                      | false    |
+| matrix_commands          | `string`  | A JSON array of commands to run in the static checks matrix, each executed via `poetry run`                                              | `["pylint app", "black --check .", "ruff check .", "mypy app/", "bandit -r app"]` | false    |
+| semgrep_extra_args       | `string`  | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'`                                                 | false    |
+| semgrep_sarif_path       | `string`  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`                                                          | false    |
+| semgrep_upload_type      | `string`  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips | `sarif`                                                                  | false    |
+| trufflehog_extra_args    | `string`  | Extra arguments to be passed to the TruffleHog CLI                                                                                        | `--results=verified,unknown`                                             | false    |
+
+#### Permissions
+
+| Access                   | Jobs used       | Level | Reason                                                      | Conditions                          |
+| ------------------------ | --------------- | ----- | ----------------------------------------------------------- | ----------------------------------- |
+| `contents: read`         | `static-checks` | Job   | To GET repository contents for static analysis              | N/A                                 |
+| `contents: read`         | `scan-secrets`  | Job   | To GET repository contents and history for secret scanning  | `inputs.enable_trufflehog_action`   |
+| `contents: read`         | `scan-vulns`    | Job   | To GET repository contents for vulnerability scanning       | `inputs.enable_semgrep_action`      |
+| `actions: read`          | `scan-vulns`    | Job   | To GET actions metadata for the scan                        | `inputs.enable_semgrep_action`      |
+| `security-events: write` | `scan-vulns`    | Job   | To POST new code scanning alerts based on the SARIF report  | `inputs.semgrep_upload_type: sarif` |
+
+#### Workflow Description
+
+This GitHub Actions workflow runs a configurable matrix of static checks on a Poetry project, optionally accompanied by secret and vulnerability scanning.
+
+1. **Static Checks**: For each command in `matrix_commands`, sets up Python, installs Poetry and the project dependencies, then runs the command via `poetry run` in a dedicated matrix job (`fail-fast: false`).
+2. **Secrets Scanning (Optional)**: When `enable_trufflehog_action` is `true`, runs TruffleHog against the branch for both verified and unverified secrets.
+3. **Vulnerability Scanning (Optional)**: When `enable_semgrep_action` is `true` (and the actor is not `dependabot[bot]`), runs Semgrep CE and uploads the results either as a SARIF report to GitHub Advanced Security or as an artefact, depending on `semgrep_upload_type`.
 
 ### [Poetry Tests](.github/workflows/tests-poetry.yml) ([examples](examples/tests-poetry.md))
 
-Runs unit/integration tests for Poetry projects using pytest and compares coverage between the PR branch and `main`.
+Runs unit/integration tests for Poetry projects using pytest and compares coverage between the PR branch and `main`. Each test path runs as a separate matrix job. When coverage is enabled, coverage is collected per test group on both the current branch and `main`, and a comparison summary is published to the job summary, failing the run if coverage drops below the configured thresholds.
+
+#### Inputs
+
+| Input                | Type      | Description                                                                                                                               | Default                              | Required |
+| -------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | -------- |
+| env_vars             | `string`  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                 | false    |
+| pre_test_command     | `string`  | Optional command to execute before the main test command                                                                                  | `""`                                 | false    |
+| pull_ghcr            | `boolean` | Whether to login to GitHub Container Registry before docker compose                                                                       | `false`                              | false    |
+| docker_compose_file  | `string`  | The Docker Compose file to use for setting up dependencies                                                                                 | `docker-compose.yml`                 | false    |
+| python_version       | `string`  | The Python version to use                                                                                                                 | `3.14`                               | false    |
+| working_directory    | `string`  | The working directory to run the tests from                                                                                               | `.`                                  | false    |
+| tests                | `string`  | JSON array of test paths to run with pytest                                                                                               | `["tests/unit", "tests/integration"]` | false    |
+| pytest_args          | `string`  | Extra arguments to pass to pytest                                                                                                          | `-v -s`                              | false    |
+| coverage             | `boolean` | Whether to collect and report code coverage                                                                                               | `true`                               | false    |
+| coverage_fail_under  | `number`  | Fail the run if coverage for a test group falls below this percentage                                                                     | `50`                                 | false    |
+| coverage_max_drop    | `number`  | Fail the run if coverage for a test group drops more than this many percentage points relative to `main`                                  | `0`                                  | false    |
+
+#### Permissions
+
+| Access           | Jobs used  | Level | Reason                                                                 | Conditions         |
+| ---------------- | ---------- | ----- | ---------------------------------------------------------------------- | ------------------ |
+| `contents: read` | `setup`    | Job   | To GET repository contents and determine branch information           | N/A                |
+| `contents: read` | `tests`    | Job   | To GET repository contents and checkout different branches for testing | N/A                |
+| `packages: read` | `tests`    | Job   | To GET packages from GitHub Container Registry when pulling images     | `inputs.pull_ghcr` |
+| `contents: read` | `coverage` | Job   | To GET repository contents for coverage comparison                     | `inputs.coverage`  |
+
+> [!NOTE]
+> Unlike the [NPM Tests](#npm-tests-examples) workflow, the coverage comparison is written to the GitHub Actions job summary rather than posted as a pull-request comment, so `pull-requests: write` is not required.
+
+#### Workflow Description
+
+This GitHub Actions workflow runs pytest in a matrix strategy and, when enabled, compares coverage between the current branch and `main`.
+
+1. **Setup**: Determines whether the run is on `main`, builds the branch matrix (current branch plus `main` for comparison when coverage is enabled), and generates a unique artifact prefix.
+2. **Tests**: For each test path and branch, sets up Python, installs Poetry and dependencies, sets environment variables from `env_vars`, optionally logs in to GHCR and brings up Docker Compose dependencies, runs an optional `pre_test_command`, then runs pytest (under `coverage` when enabled) and uploads the coverage JSON per test group.
+3. **Coverage**: Downloads the current-branch and `main` coverage summaries, builds a per-group comparison table in the job summary, and fails the run if any group is below `coverage_fail_under` or drops by more than `coverage_max_drop` relative to `main`.
 
 ### [Poetry E2E tests](.github/workflows/tests-e2e-poetry.yml) ([examples](examples/tests-e2e-poetry.md))
 
-Runs end-to-end tests for Poetry projects (optionally using `docker-compose` / `docker bake`).
+Runs end-to-end tests for Poetry projects (optionally using `docker-compose` / `docker bake`). Supports building dependency containers with Docker Bake, optionally setting up Node.js alongside Python, and running a customisable test command.
+
+#### Inputs
+
+| Input               | Type      | Description                                                                                                                               | Default                             | Required |
+| ------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | -------- |
+| env_vars            | `string`  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                | false    |
+| pre_test_command    | `string`  | Optional command to execute before the main test command                                                                                  | `""`                                | false    |
+| pull_ghcr           | `boolean` | Whether to login to GitHub Container Registry before docker compose                                                                       | `false`                             | false    |
+| docker_compose_file | `string`  | The Docker Compose file used for building the testing environment                                                                         | `docker-compose.yml`                | false    |
+| python_version      | `string`  | The Python version to use                                                                                                                 | `3.14`                              | false    |
+| setup_node          | `boolean` | Whether to also set up Node.js (e.g. for projects whose E2E tests use a Node-based runner)                                                 | `false`                             | false    |
+| node_version        | `string`  | The node version to use when `setup_node` is enabled                                                                                      | `24.x`                              | false    |
+| working_directory   | `string`  | The working directory to run the tests from                                                                                               | `.`                                 | false    |
+| test_command        | `string`  | Command used to run E2E tests, which can be customised as needed                                                                          | `poetry run pytest tests/e2e -v -s` | false    |
+
+#### Permissions
+
+| Access           | Jobs used   | Level | Reason                                                             | Conditions         |
+| ---------------- | ----------- | ----- | ------------------------------------------------------------------ | ------------------ |
+| `contents: read` | `e2e-tests` | Job   | To GET repository contents                                         | N/A                |
+| `packages: read` | `e2e-tests` | Job   | To GET packages from GitHub Container Registry when pulling images | `inputs.pull_ghcr` |
+
+#### Workflow Description
+
+This GitHub Actions workflow runs end-to-end tests for a Poetry project within a Dockerised environment.
+
+1. **Set Environment Variables**: Parses `env_vars` from JSON and applies them to the workflow environment.
+2. **Container Setup (Optional)**: Optionally logs in to GHCR, then configures Docker Buildx and builds the E2E containers with Docker Bake from the provided Docker Compose file.
+3. **Toolchain Setup**: Optionally sets up Node.js (when `setup_node` is `true`), then sets up Python and installs Poetry and the project dependencies.
+4. **Pre-Test Command (Optional)**: Runs `pre_test_command` if provided.
+5. **Run E2E Tests**: Executes `test_command`.
 
 ### [NPM Static Checks](.github/workflows/static-checks-npm.yml) ([examples](examples/static-checks.md))
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Shared github workflows created by the `digicatapult` organisation.
 - [Generate SBOM](#generate-sbom-examples)
 - [Scan Secrets](#scan-secrets-examples)
 - [Scan Vulnerabilities](#scan-vulnerabilities-examples)
+- [ZAP Scan](#zap-scan-examples)
 
 ## Workflows
 
@@ -678,31 +679,31 @@ Runs OWASP ZAP Dynamic Application Security Testing (DAST) scans against a runni
 
 #### Inputs
 
-| Input                 | Type      | Description                                                                                          | Default                            | Required |
-| --------------------- | --------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
-| `matrix_scans`        | `string`  | JSON array of ZAP scan types to run: `baseline`, `full`, `api`, `automation-framework`               | `'["baseline"]'`                   | false    |
-| `target`              | `string`  | URL of the web application to scan (used by `baseline`, `full`, and `api` scan types)                | `http://localhost:3000`            | false    |
-| `env_vars`            | `string`  | JSON object of extra environment variables to inject                                                 | `{}`                               | false    |
-| `docker_compose_file` | `string`  | Docker Compose file used to bring up the application stack before scanning                           | `""`                               | false    |
-| `pull_ghcr`           | `boolean` | Log in to GitHub Container Registry before pulling images (e.g. if using private/custom proxy image) | `false`                            | false    |
-| `pre_scan_command`    | `string`  | Arbitrary shell command to start the application (e.g. `npm ci && npm start &`)                      | `""`                               | false    |
-| `target_wait_timeout` | `number`  | Seconds to poll `target` for a successful response before failing                                    | `60`                               | false    |
-| `rules_file_name`     | `string`  | Relative path to a ZAP rules TSV file for suppressing known alerts                                   | `""`                               | false    |
-| `cmd_options`         | `string`  | Additional ZAP CLI options passed to all scan types                                                  | `""`                               | false    |
-| `docker_name`         | `string`  | Custom ZAP Docker image name; defaults to the stable ZAP image                                       | `"ghcr.io/zaproxy/zaproxy:stable"` | false    |
-| `allow_issue_writing` | `boolean` | Create or update a GitHub issue in the repository with ZAP findings; requires `issues: write`        | `false`                            | false    |
-| `fail_action`         | `boolean` | Fail the job if ZAP identifies any alerts                                                            | `false`                            | false    |
-| `artifact_name`       | `string`  | Base name for uploaded scan report artifacts; suffixed with the scan type (e.g. `zap_scan-baseline`) | `zap_scan`                         | false    |
-| `api_scan_format`     | `string`  | API definition format for the `api` scan type: `openapi`, `soap`, or `graphql`                       | `openapi`                          | false    |
-| `automation_plan`     | `string`  | File path or URL of the ZAP Automation Framework plan; required when using `automation-framework`    | `""`                               | false    |
+| Input               | Type    | Description                                                                                          | Default                            | Required |
+| ------------------- | ------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
+| matrix_scans        | string  | JSON array of ZAP scan types to run: `baseline`, `full`, `api`, `automation-framework`               | `'["baseline"]'`                   | false    |
+| target              | string  | URL of the web application to scan (used by `baseline`, `full`, and `api` scan types)                | `http://localhost:3000`            | false    |
+| env_vars            | string  | JSON object of extra environment variables to inject                                                 | `{}`                               | false    |
+| docker_compose_file | string  | Docker Compose file used to bring up the application stack before scanning                           | `""`                               | false    |
+| pull_ghcr           | boolean | Log in to GitHub Container Registry before pulling images (e.g. if using private/custom proxy image) | `false`                            | false    |
+| pre_scan_command    | string  | Arbitrary shell command to start the application (e.g. `npm ci && npm start &`)                       | `""`                               | false    |
+| target_wait_timeout | number  | Seconds to poll `target` for a successful response before failing                                    | `60`                               | false    |
+| rules_file_name     | string  | Relative path to a ZAP rules TSV file for suppressing known alerts                                   | `""`                               | false    |
+| cmd_options         | string  | Additional ZAP CLI options passed to all scan types                                                  | `""`                               | false    |
+| docker_name         | string  | Custom ZAP Docker image name; defaults to the stable ZAP image                                       | `"ghcr.io/zaproxy/zaproxy:stable"` | false    |
+| allow_issue_writing | boolean | Create or update a GitHub issue in the repository with ZAP findings; requires `issues: write`        | `false`                            | false    |
+| fail_action         | boolean | Fail the job if ZAP identifies any alerts                                                             | `false`                            | false    |
+| artifact_name       | string  | Base name for uploaded scan report artifacts; suffixed with the scan type (e.g. `zap_scan-baseline`) | `zap_scan`                         | false    |
+| api_scan_format     | string  | API definition format for the `api` scan type: `openapi`, `soap`, or `graphql`                       | `openapi`                          | false    |
+| automation_plan     | string  | File path or URL of the ZAP Automation Framework plan; required when using `automation-framework`    | `""`                               | false    |
 
 #### Permissions
 
-| Access           | Jobs used  | Level    | Reason                                                                 | When                        |
-| ---------------- | ---------- | -------- | ---------------------------------------------------------------------- | --------------------------- |
-| `contents: read` | `zap-scan` | Workflow | To GET repository contents and pass rules files into the ZAP container | Always                      |
-| `packages: read` | `zap-scan` | Job      | To authenticate with GHCR and pull Docker images                       | `pull_ghcr: true`           |
-| `issues: write`  | `zap-scan` | Job      | To allow ZAP to create or update a GitHub issue with scan findings     | `allow_issue_writing: true` |
+| Access           | Jobs used  | Level    | Reason                                                                 | Conditions                   |
+| ---------------- | ---------- | -------- | ---------------------------------------------------------------------- | ---------------------------- |
+| `contents: read` | `zap-scan` | Workflow | To GET repository contents and pass rules files into the ZAP container | N/A                          |
+| `packages: read` | `zap-scan` | Job      | To authenticate with GHCR and pull Docker images                       | `inputs.pull_ghcr`           |
+| `issues: write`  | `zap-scan` | Job      | To allow ZAP to create or update a GitHub issue with scan findings     | `inputs.allow_issue_writing` |
 
 #### Workflow Description
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ Synchronises the version in a `package.json` on a pull-request branch in relatio
 
 #### Inputs
 
-| Input          | Type     | Description                             | Default |
-| -------------- | -------- | --------------------------------------- | ------- |
-| `pr-number`    | `number` | The PR to run this workflow for         |         |
-| `trunk-branch` | `string` | The trunk branch to synchronise against | `main`  |
+| Input        | Type   | Description                             | Default | Required |
+| ------------ | ------ | --------------------------------------- | ------- | -------- |
+| pr-number    | number | The PR to run this workflow for         |         | true     |
+| trunk-branch | string | The trunk branch to synchronise against | `main`  | true     |
 
 #### Permissions
 
-| Access                 | Jobs used             | Level    | Reason                                                                            |
-| ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- |
-| `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` |
-| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                     |
+| Access                 | Jobs used             | Level    | Reason                                                                            | Conditions |
+| ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- | ---------- |
+| `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` | N/A        |
+| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                      | N/A        |
 
 #### Secrets
 
@@ -73,17 +73,17 @@ Synchronises the version in a `pyproject.toml` on a pull-request branch in relat
 
 #### Inputs
 
-| Input          | Type     | Description                             | Default |
-| -------------- | -------- | --------------------------------------- | ------- |
-| `pr-number`    | `number` | The PR to run this workflow for         |         |
-| `trunk-branch` | `string` | The trunk branch to synchronise against | `main`  |
+| Input        | Type   | Description                             | Default | Required |
+| ------------ | ------ | --------------------------------------- | ------- | -------- |
+| pr-number    | number | The PR to run this workflow for         |         | true     |
+| trunk-branch | string | The trunk branch to synchronise against | `main`  | true     |
 
 #### Permissions
 
-| Access                 | Jobs used             | Level    | Reason                                                                            |
-| ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- |
-| `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` |
-| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                      |
+| Access                 | Jobs used             | Level    | Reason                                                                            | Conditions |
+| ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- | ---------- |
+| `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` | N/A        |
+| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                      | N/A        |
 
 #### Secrets
 
@@ -100,18 +100,18 @@ Synchronises the version in `package.json` for all open pull-requests that have 
 
 #### Inputs
 
-| Input          | Type     | Description                             | Default |
-| -------------- | -------- | --------------------------------------- | ------- |
-| `trunk-branch` | `string` | The trunk branch to synchronise against | `main`  |
+| Input        | Type   | Description                             | Default | Required |
+| ------------ | ------ | --------------------------------------- | ------- | -------- |
+| trunk-branch | string | The trunk branch to synchronise against | `main`  | true     |
 
 #### Permissions
 
-| Access                 | Jobs used                   | Level | Reason                                                                                     |
-| ---------------------- | --------------------------- | ----- | ------------------------------------------------------------------------------------------ |
-| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                 |
-| `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                  |
-| `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-npm.yml` and POST commits against all open pull requests |
-| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs     |
+| Access                 | Jobs used                   | Level | Reason                                                                                     | Conditions |
+| ---------------------- | --------------------------- | ----- | ------------------------------------------------------------------------------------------ | ---------- |
+| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                 | N/A        |
+| `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                  | N/A        |
+| `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-npm.yml` and POST commits against all open pull requests | N/A        |
+| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs     | N/A        |
 
 #### Secrets
 
@@ -128,18 +128,18 @@ Synchronises the version in `pyproject.toml` for all open pull requests that hav
 
 #### Inputs
 
-| Input          | Type     | Description                             | Default |
-| -------------- | -------- | --------------------------------------- | ------- |
-| `trunk-branch` | `string` | The trunk branch to synchronise against | `main`  |
+| Input        | Type   | Description                             | Default | Required |
+| ------------ | ------ | --------------------------------------- | ------- | -------- |
+| trunk-branch | string | The trunk branch to synchronise against | `main`  | true     |
 
 #### Permissions
 
-| Access                 | Jobs used                   | Level | Reason                                                                                        |
-| ---------------------- | --------------------------- | ----- | --------------------------------------------------------------------------------------------- |
-| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                    |
-| `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                     |
-| `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-poetry.yml` and POST commits against all open pull requests |
-| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs        |
+| Access                 | Jobs used                   | Level | Reason                                                                                        | Conditions |
+| ---------------------- | --------------------------- | ----- | --------------------------------------------------------------------------------------------- | ---------- |
+| `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                    | N/A        |
+| `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                     | N/A        |
+| `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-poetry.yml` and POST commits against all open pull requests | N/A        |
+| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs         | N/A        |
 
 #### Secrets
 
@@ -156,13 +156,13 @@ Builds a Docker container and optionally pushes it to GitHub Container Registry 
 
 #### Inputs
 
-| Input            | Type    | Description                                                                                                           | Default                     | Required |
+| Input            | Type    | Description                                                                                                            | Default                     | Required |
 | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------- | -------- |
 | build_args       | string  | Build arguments to pass to Docker build                                                                               | `""`                        | false    |
 | env_vars         | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                        | false    |
 | pull_dhi         | boolean | Whether to login to Docker Hardened Images registry before building                                                   | `false`                     | false    |
-| push_dockerhub   | boolean | Whether to push the built image to DockerHub                                                                          | `false`                     | false    |
-| push_ghcr        | boolean | Whether to push the built image to GHCR                                                                               | `false`                     | false    |
+| push_dockerhub   | boolean | Whether to push the built image to DockerHub                                                                           | `false`                     | false    |
+| push_ghcr        | boolean | Whether to push the built image to GHCR                                                                                | `false`                     | false    |
 | docker_platforms | string  | Specifies architectures to build the container for                                                                    | `"linux/amd64,linux/arm64"` | false    |
 | docker_file      | string  | Dockerfile to be used for building the container                                                                      | `Dockerfile`                | false    |
 
@@ -224,9 +224,9 @@ Determines the versioning information of the repository, setting output values r
 
 #### Permissions
 
-| Access           | Jobs used       | Level    | Reason                                               |
-| ---------------- | --------------- | -------- | ---------------------------------------------------- |
-| `contents: read` | `check-version` | Workflow | To GET repository contents and version from git tags |
+| Access           | Jobs used       | Level    | Reason                                               | Conditions |
+| ---------------- | --------------- | -------- | ---------------------------------------------------- | ---------- |
+| `contents: read` | `check-version` | Workflow | To GET repository contents and version from git tags | N/A        |
 
 #### Workflow Description
 
@@ -238,10 +238,10 @@ Automates the release process on GitHub, creating a versioned release based on t
 
 #### Inputs
 
-| Input    | Type    | Description                                                                                                                               | Default |
-| -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| env_vars | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`    |
-| get_sbom | boolean | An option to disable the retrieval of SBOM artefacts, e.g. if none are expected from other workflows                                      | `true`  |
+| Input    | Type    | Description                                                                                                                               | Default | Required |
+| -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- |
+| env_vars | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`    | false    |
+| get_sbom | boolean | An option to enable retrieval of SBOM artefacts from other workflows; leave `false` if none are expected                                  | `false` | false    |
 
 #### Permissions
 
@@ -279,11 +279,11 @@ Publishes an NPM package to the specified registry, optionally building the pack
 
 #### Permissions
 
-| Access            | Jobs used     | Level    | Reason                                                                                                       |
-| ----------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| `contents: write` | `publish-npm` | Workflow | To both GET and POST repository contents, as the READMEs are included in the package's documentation         |
-| `id-token: write` | `publish-npm` | Workflow | To request an OCID token and POST to confirm details about the provenance of a package in the NPMJS registry |
-| `packages: write` | `publish-npm` | Workflow | To POST a package to a GitHub Packages registry using `npm publish`                                          |
+| Access            | Jobs used     | Level    | Reason                                                                                                       | Conditions |
+| ----------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------ | ---------- |
+| `contents: write` | `publish-npm` | Workflow | To both GET and POST repository contents, as the READMEs are included in the package's documentation         | N/A        |
+| `id-token: write` | `publish-npm` | Workflow | To request an OCID token and POST to confirm details about the provenance of a package in the NPMJS registry | N/A        |
+| `packages: write` | `publish-npm` | Workflow | To POST a package to a GitHub Packages registry using `npm publish`                                          | N/A        |
 
 #### Secrets
 
@@ -312,29 +312,29 @@ For backwards compatibility, the legacy filename [.github/workflows/generate-sbo
 
 #### Inputs
 
-| Input                 | Type    | Description                                                                                                                               | Default                               | Required |
-| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------- |
-| dtrack_project_name   | string  | A project name to use within Dependency Track                                                                                             | `${{ github.event.repository.name }}` | false    |
-| enable_check_version  | boolean | An option to enable the use of the digicatapult/check-version action                                                                      | `false`                               | false    |
-| enable_dtrack_project | boolean | An option to enable the use of Dependency Track                                                                                           | `false`                               | false    |
-| package_manager       | string  | Package manager for version detection. Options: `npm`, `poetry`                                                                          | `npm`                                 | false    |
-| env_vars              | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                  | false    |
-| node_version          | string  | The node version to use                                                                                                                   | `24.x`                                | false    |
-| python_version        | string  | The Python version to use (for Poetry / `cdxgen` SBOMs)                                                                                    | `3.14`                                | false    |
-| sbom_tool             | string  | SBOM generation tool to use. Options: `@cyclonedx/cyclonedx-npm`, `@cyclonedx/cdxgen`                                                     | `@cyclonedx/cyclonedx-npm`            | false    |
-| sbom_format           | string  | SBOM output format. Options: `json`, `xml`                                                                                                | `json`                                | false    |
-| sbom_output_file      | string  | Custom output filename. Defaults to `{repo-name}.cdx.{format}`                                                                            | `""`                                  | false    |
-| npm_build_command     | string  | Optional build command to run before generating SBOM                                                                                      | `""`                                  | false    |
-| additional_args       | string  | Additional arguments to pass to the SBOM generation tool                                                                                  | `""`                                  | false    |
-| install_python_deps   | boolean | Install Python dependencies before SBOM generation                                                                                       | `false`                               | false    |
-| python_install_command | string | Optional custom command to install Python dependencies                                                                                   | `""`                                  | false    |
-| upload_artifact       | boolean | Whether to upload the SBOM as a workflow artifact                                                                                         | `true`                                | false    |
+| Input                  | Type    | Description                                                                                                                                | Default                               | Required |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | -------- |
+| dtrack_project_name    | string  | A project name to use within Dependency Track                                                                                              | `${{ github.event.repository.name }}` | false    |
+| enable_check_version   | boolean | An option to enable the use of the digicatapult/check-version action                                                                       | `false`                               | false    |
+| enable_dtrack_project  | boolean | An option to enable the use of Dependency Track                                                                                            | `false`                               | false    |
+| package_manager        | string  | Package manager for version detection. Options: `npm`, `poetry`                                                                            | `npm`                                 | false    |
+| env_vars               | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                  | false    |
+| node_version           | string  | The node version to use                                                                                                                    | `24.x`                                | false    |
+| python_version         | string  | The Python version to use (for Poetry / `cdxgen` SBOMs)                                                                                    | `3.14`                                | false    |
+| sbom_tool              | string  | SBOM generation tool to use. Options: `@cyclonedx/cyclonedx-npm`, `@cyclonedx/cdxgen`                                                       | `@cyclonedx/cyclonedx-npm`            | false    |
+| sbom_format            | string  | SBOM output format. Options: `json`, `xml`                                                                                                 | `json`                                | false    |
+| sbom_output_file       | string  | Custom output filename. Defaults to `{repo-name}.cdx.{format}`                                                                             | `""`                                  | false    |
+| npm_build_command      | string  | Optional build command to run before generating SBOM                                                                                       | `""`                                  | false    |
+| additional_args        | string  | Additional arguments to pass to the SBOM generation tool                                                                                   | `""`                                  | false    |
+| install_python_deps    | boolean | Install Python dependencies before SBOM generation                                                                                         | `false`                               | false    |
+| python_install_command | string  | Optional custom command to install Python dependencies                                                                                     | `""`                                  | false    |
+| upload_artifact        | boolean | Whether to upload the SBOM as a workflow artifact                                                                                          | `true`                                | false    |
 
 #### Permissions
 
-| Access           | Jobs used       | Level    | Reason                     |
-| ---------------- | --------------- | -------- | -------------------------- |
-| `contents: read` | `generate-sbom` | Workflow | To GET repository contents |
+| Access           | Jobs used       | Level    | Reason                     | Conditions |
+| ---------------- | --------------- | -------- | -------------------------- | ---------- |
+| `contents: read` | `generate-sbom` | Workflow | To GET repository contents | N/A        |
 
 #### Secrets
 
@@ -346,9 +346,9 @@ For backwards compatibility, the legacy filename [.github/workflows/generate-sbo
 
 #### Outputs
 
-| Output    | Description                         |
-| --------- | ----------------------------------- |
-| sbom_file | The name of the generated SBOM file |
+| Output    | Type   | Description                         |
+| --------- | ------ | ----------------------------------- |
+| sbom_file | string | The name of the generated SBOM file |
 
 #### Workflow Description
 
@@ -368,28 +368,28 @@ Runs static analysis for Poetry projects (default matrix includes `pylint`, `bla
 
 #### Inputs
 
-| Input                    | Type      | Description                                                                                                                               | Default                                                                  | Required |
-| ------------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------- |
-| enable_semgrep_action    | `boolean` | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | `true`                                                                   | false    |
-| enable_trufflehog_action | `boolean` | An option to enable a TruffleHog GitHub Action, scanning for exposed secrets                                                              | `false`                                                                  | false    |
-| env_vars                 | `string`  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                                                     | false    |
-| python_version           | `string`  | The Python version to use                                                                                                                 | `3.14`                                                                   | false    |
-| working_directory        | `string`  | The working directory to run the checks from                                                                                              | `.`                                                                      | false    |
-| matrix_commands          | `string`  | A JSON array of commands to run in the static checks matrix, each executed via `poetry run`                                              | `["pylint app", "black --check .", "ruff check .", "mypy app/", "bandit -r app"]` | false    |
-| semgrep_extra_args       | `string`  | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'`                                                 | false    |
-| semgrep_sarif_path       | `string`  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`                                                          | false    |
-| semgrep_upload_type      | `string`  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips | `sarif`                                                                  | false    |
-| trufflehog_extra_args    | `string`  | Extra arguments to be passed to the TruffleHog CLI                                                                                        | `--results=verified,unknown`                                             | false    |
+| Input                    | Type    | Description                                                                                                                                | Default                                                                           | Required |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | -------- |
+| enable_semgrep_action    | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                            | `true`                                                                            | false    |
+| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Action, scanning for exposed secrets                                                               | `false`                                                                           | false    |
+| env_vars                 | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                                                              | false    |
+| python_version           | string  | The Python version to use                                                                                                                  | `3.14`                                                                            | false    |
+| working_directory        | string  | The working directory to run the checks from                                                                                               | `.`                                                                               | false    |
+| matrix_commands          | string  | A JSON array of commands to run in the static checks matrix, each executed via `poetry run`                                                | `["pylint app", "black --check .", "ruff check .", "mypy app/", "bandit -r app"]` | false    |
+| semgrep_extra_args       | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                         | `'--config="p/default"'`                                                          | false    |
+| semgrep_sarif_path       | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                        | `semgrep.sarif`                                                                   | false    |
+| semgrep_upload_type      | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips  | `sarif`                                                                           | false    |
+| trufflehog_extra_args    | string  | Extra arguments to be passed to the TruffleHog CLI                                                                                         | `--results=verified,unknown`                                                      | false    |
 
 #### Permissions
 
-| Access                   | Jobs used       | Level | Reason                                                      | Conditions                          |
-| ------------------------ | --------------- | ----- | ----------------------------------------------------------- | ----------------------------------- |
-| `contents: read`         | `static-checks` | Job   | To GET repository contents for static analysis              | N/A                                 |
-| `contents: read`         | `scan-secrets`  | Job   | To GET repository contents and history for secret scanning  | `inputs.enable_trufflehog_action`   |
-| `contents: read`         | `scan-vulns`    | Job   | To GET repository contents for vulnerability scanning       | `inputs.enable_semgrep_action`      |
-| `actions: read`          | `scan-vulns`    | Job   | To GET actions metadata for the scan                        | `inputs.enable_semgrep_action`      |
-| `security-events: write` | `scan-vulns`    | Job   | To POST new code scanning alerts based on the SARIF report  | `inputs.semgrep_upload_type: sarif` |
+| Access                   | Jobs used       | Level | Reason                                                     | Conditions                          |
+| ------------------------ | --------------- | ----- | ---------------------------------------------------------- | ----------------------------------- |
+| `contents: read`         | `static-checks` | Job   | To GET repository contents for static analysis             | N/A                                 |
+| `contents: read`         | `scan-secrets`  | Job   | To GET repository contents and history for secret scanning | `inputs.enable_trufflehog_action`   |
+| `contents: read`         | `scan-vulns`    | Job   | To GET repository contents for vulnerability scanning      | `inputs.enable_semgrep_action`      |
+| `actions: read`          | `scan-vulns`    | Job   | To GET actions metadata for the scan                       | `inputs.enable_semgrep_action`      |
+| `security-events: write` | `scan-vulns`    | Job   | To POST new code scanning alerts based on the SARIF report | `inputs.semgrep_upload_type: sarif` |
 
 #### Workflow Description
 
@@ -405,25 +405,25 @@ Runs unit/integration tests for Poetry projects using pytest and compares covera
 
 #### Inputs
 
-| Input                | Type      | Description                                                                                                                               | Default                              | Required |
-| -------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | -------- |
-| env_vars             | `string`  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                 | false    |
-| pre_test_command     | `string`  | Optional command to execute before the main test command                                                                                  | `""`                                 | false    |
-| pull_ghcr            | `boolean` | Whether to login to GitHub Container Registry before docker compose                                                                       | `false`                              | false    |
-| docker_compose_file  | `string`  | The Docker Compose file to use for setting up dependencies                                                                                 | `docker-compose.yml`                 | false    |
-| python_version       | `string`  | The Python version to use                                                                                                                 | `3.14`                               | false    |
-| working_directory    | `string`  | The working directory to run the tests from                                                                                               | `.`                                  | false    |
-| tests                | `string`  | JSON array of test paths to run with pytest                                                                                               | `["tests/unit", "tests/integration"]` | false    |
-| pytest_args          | `string`  | Extra arguments to pass to pytest                                                                                                          | `-v -s`                              | false    |
-| coverage             | `boolean` | Whether to collect and report code coverage                                                                                               | `true`                               | false    |
-| coverage_fail_under  | `number`  | Fail the run if coverage for a test group falls below this percentage                                                                     | `50`                                 | false    |
-| coverage_max_drop    | `number`  | Fail the run if coverage for a test group drops more than this many percentage points relative to `main`                                  | `0`                                  | false    |
+| Input               | Type    | Description                                                                                                                                | Default                                | Required |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | -------- |
+| env_vars            | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                   | false    |
+| pre_test_command    | string  | Optional command to execute before the main test command                                                                                   | `""`                                   | false    |
+| pull_ghcr           | boolean | Whether to login to GitHub Container Registry before docker compose                                                                        | `false`                                | false    |
+| docker_compose_file | string  | The Docker Compose file to use for setting up dependencies                                                                                  | `docker-compose.yml`                   | false    |
+| python_version      | string  | The Python version to use                                                                                                                  | `3.14`                                 | false    |
+| working_directory   | string  | The working directory to run the tests from                                                                                                | `.`                                    | false    |
+| tests               | string  | JSON array of test paths to run with pytest                                                                                                | `["tests/unit", "tests/integration"]`  | false    |
+| pytest_args         | string  | Extra arguments to pass to pytest                                                                                                           | `-v -s`                                | false    |
+| coverage            | boolean | Whether to collect and report code coverage                                                                                                | `true`                                 | false    |
+| coverage_fail_under | number  | Fail the run if coverage for a test group falls below this percentage                                                                      | `50`                                   | false    |
+| coverage_max_drop   | number  | Fail the run if coverage for a test group drops more than this many percentage points relative to `main`                                   | `0`                                    | false    |
 
 #### Permissions
 
 | Access           | Jobs used  | Level | Reason                                                                 | Conditions         |
 | ---------------- | ---------- | ----- | ---------------------------------------------------------------------- | ------------------ |
-| `contents: read` | `setup`    | Job   | To GET repository contents and determine branch information           | N/A                |
+| `contents: read` | `setup`    | Job   | To GET repository contents and determine branch information            | N/A                |
 | `contents: read` | `tests`    | Job   | To GET repository contents and checkout different branches for testing | N/A                |
 | `packages: read` | `tests`    | Job   | To GET packages from GitHub Container Registry when pulling images     | `inputs.pull_ghcr` |
 | `contents: read` | `coverage` | Job   | To GET repository contents for coverage comparison                     | `inputs.coverage`  |
@@ -445,17 +445,17 @@ Runs end-to-end tests for Poetry projects (optionally using `docker-compose` / `
 
 #### Inputs
 
-| Input               | Type      | Description                                                                                                                               | Default                             | Required |
-| ------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | -------- |
-| env_vars            | `string`  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                | false    |
-| pre_test_command    | `string`  | Optional command to execute before the main test command                                                                                  | `""`                                | false    |
-| pull_ghcr           | `boolean` | Whether to login to GitHub Container Registry before docker compose                                                                       | `false`                             | false    |
-| docker_compose_file | `string`  | The Docker Compose file used for building the testing environment                                                                         | `docker-compose.yml`                | false    |
-| python_version      | `string`  | The Python version to use                                                                                                                 | `3.14`                              | false    |
-| setup_node          | `boolean` | Whether to also set up Node.js (e.g. for projects whose E2E tests use a Node-based runner)                                                 | `false`                             | false    |
-| node_version        | `string`  | The node version to use when `setup_node` is enabled                                                                                      | `24.x`                              | false    |
-| working_directory   | `string`  | The working directory to run the tests from                                                                                               | `.`                                 | false    |
-| test_command        | `string`  | Command used to run E2E tests, which can be customised as needed                                                                          | `poetry run pytest tests/e2e -v -s` | false    |
+| Input               | Type    | Description                                                                                                                                | Default                             | Required |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | -------- |
+| env_vars            | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                | false    |
+| pre_test_command    | string  | Optional command to execute before the main test command                                                                                   | `""`                                | false    |
+| pull_ghcr           | boolean | Whether to login to GitHub Container Registry before docker compose                                                                        | `false`                             | false    |
+| docker_compose_file | string  | The Docker Compose file used for building the testing environment                                                                          | `docker-compose.yml`                | false    |
+| python_version      | string  | The Python version to use                                                                                                                  | `3.14`                              | false    |
+| setup_node          | boolean | Whether to also set up Node.js (e.g. for projects whose E2E tests use a Node-based runner)                                                  | `false`                             | false    |
+| node_version        | string  | The node version to use when `setup_node` is enabled                                                                                       | `24.x`                              | false    |
+| working_directory   | string  | The working directory to run the tests from                                                                                                | `.`                                 | false    |
+| test_command        | string  | Command used to run E2E tests, which can be customised as needed                                                                           | `poetry run pytest tests/e2e -v -s` | false    |
 
 #### Permissions
 
@@ -480,17 +480,17 @@ Performs configurable static analysis checks on an NPM project, such as linting,
 
 #### Inputs
 
-| Input                    | Type   | Description                                                                                                                               | Default                        | Required |
-| ------------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | -------- |
-| enable_semgrep_action    | bool   | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | true                           | false    |
-| enable_trufflehog_action | bool   | An option to enable a TruffleHog GitHub Actions, scanning for exposed secrets                                                             | false                          | false    |
-| env_vars                 | string | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                           | false    |
-| node_version             | string | The node version to use                                                                                                                   | `24.x`                         | false    |
-| matrix_commands          | string | A JSON array of commands to run in the static checks matrix, each representing an NPM script defined in the package                       | `["lint","depcheck","check"]`  | false    |
-| semgrep_extra_args       | string | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'`       | false    |
-| semgrep_sarif_path       | string | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`                | false    |
-| semgrep_upload_type      | string | Upload format for Semgrep results; "sarif" uses the CodeQL SARIF upload action, "artefact" uses vanilla artefact upload, and "none" skips | `sarif`                        | false    |
-| trufflehog_extra_args    | string | Extra arguments to be passed to the TruffleHog CLI                                                                                        | `"--results=verified,unknown"` | true     |
+| Input                    | Type    | Description                                                                                                                                | Default                          | Required |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------- |
+| enable_semgrep_action    | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                            | `true`                           | false    |
+| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Actions, scanning for exposed secrets                                                              | `false`                          | false    |
+| env_vars                 | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                             | false    |
+| node_version             | string  | The node version to use                                                                                                                    | `24.x`                           | false    |
+| matrix_commands          | string  | A JSON array of commands to run in the static checks matrix, each representing an NPM script defined in the package                        | `["lint", "depcheck", "check"]`  | false    |
+| semgrep_extra_args       | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                         | `'--config="p/default"'`         | false    |
+| semgrep_sarif_path       | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                        | `semgrep.sarif`                  | false    |
+| semgrep_upload_type      | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips  | `sarif`                          | false    |
+| trufflehog_extra_args    | string  | Extra arguments to be passed to the TruffleHog CLI                                                                                         | `"--results=verified,unknown"`   | false    |
 
 #### Permissions
 
@@ -522,7 +522,7 @@ Executes end-to-end (E2E) tests for an NPM project using Docker Compose, support
 
 #### Inputs
 
-| Input               | Type    | Description                                                                                                               | Default              | Required |
+| Input               | Type    | Description                                                                                                                | Default              | Required |
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------- |
 | env_vars            | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                 | false    |
 | npm_build_command   | string  | Optional command to build the application before running tests                                                            | `""`                 | false    |
@@ -560,7 +560,7 @@ Runs specified NPM tests (e.g., unit and integration tests) with optional build 
 
 #### Inputs
 
-| Input                | Type    | Description                                                                                                           | Default                            | Required |
+| Input                | Type    | Description                                                                                                            | Default                            | Required |
 | -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
 | env_vars             | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                               | false    |
 | npm_build_command    | string  | Optional command to build the application before running tests                                                        | `""`                               | false    |
@@ -620,18 +620,18 @@ Runs scanners to detect the exposure of secrets, with the option to add in extra
 
 #### Inputs
 
-| Input                    | Type   | Description                                                                   | Default                        | Required |
-| ------------------------ | ------ | ----------------------------------------------------------------------------- | ------------------------------ | -------- |
-| base                     | string | An optional branch to base the scan on                                        | `""`                           | false    |
-| enable_trufflehog_action | bool   | An option to enable a TruffleHog GitHub Actions, scanning for exposed secrets | false                          | true     |
-| env_vars                 | string | Extra variables to be passed to the environment                               | `{}`                           | false    |
-| extra_args               | string | Extra arguments to be passed to the TruffleHog CLI                            | `"--results=verified,unknown"` | true     |
+| Input                    | Type    | Description                                                                   | Default                        | Required |
+| ------------------------ | ------- | ----------------------------------------------------------------------------- | ------------------------------ | -------- |
+| base                     | string  | An optional branch to base the scan on                                        | `""`                           | false    |
+| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Actions, scanning for exposed secrets | `true`                         | false    |
+| env_vars                 | string  | Extra variables to be passed to the environment                               | `{}`                           | false    |
+| extra_args               | string  | Extra arguments to be passed to the TruffleHog CLI                            | `"--results=verified,unknown"` | false    |
 
 #### Permissions
 
-| Access           | Jobs used    | Level    | Reason                                                     |
-| ---------------- | ------------ | -------- | ---------------------------------------------------------- |
-| `contents: read` | `trufflehog` | Workflow | To GET repository contents and history for secret scanning |
+| Access           | Jobs used    | Level    | Reason                                                     | Conditions |
+| ---------------- | ------------ | -------- | ---------------------------------------------------------- | ---------- |
+| `contents: read` | `trufflehog` | Workflow | To GET repository contents and history for secret scanning | N/A        |
 
 #### Workflow Description
 
@@ -648,20 +648,20 @@ Runs scanners to detect bugs, security vulnerabilities, and compliance issues, w
 
 #### Inputs
 
-| Input                 | Type   | Description                                                                                                                               | Default                  | Required |
-| --------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------- |
-| enable_semgrep_action | bool   | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | true                     | false    |
-| extra_args            | string | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'` | false    |
-| sarif_path            | string | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`          | false    |
-| upload_type           | string | Upload format for Semgrep results; "sarif" uses the CodeQL SARIF upload action, "artefact" uses vanilla artefact upload, and "none" skips | `sarif`                  | false    |
+| Input                 | Type    | Description                                                                                                                                | Default                  | Required |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------- |
+| enable_semgrep_action | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                            | `true`                   | false    |
+| extra_args            | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                         | `'--config="p/default"'` | false    |
+| sarif_path            | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                        | `semgrep.sarif`          | false    |
+| upload_type           | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips  | `sarif`                  | false    |
 
 #### Permissions
 
-| Access                   | Jobs used | Level    | Reason                                                     |
-| ------------------------ | --------- | -------- | ---------------------------------------------------------- |
-| `security-events: write` | `semgrep` | Workflow | To POST new code scanning alerts based on the SARIF report |
-| `contents: read`         | `semgrep` | Workflow | To GET repository contents for vulnerability scanning      |
-| `actions: read`          | `semgrep` | Workflow | To GET actions metadata for the scan                       |
+| Access                   | Jobs used | Level    | Reason                                                     | Conditions                   |
+| ------------------------ | --------- | -------- | ---------------------------------------------------------- | ---------------------------- |
+| `security-events: write` | `semgrep` | Workflow | To POST new code scanning alerts based on the SARIF report | `inputs.upload_type: sarif`  |
+| `contents: read`         | `semgrep` | Workflow | To GET repository contents for vulnerability scanning      | N/A                          |
+| `actions: read`          | `semgrep` | Workflow | To GET actions metadata for the scan                       | N/A                          |
 
 #### Workflow Description
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Synchronises the version in a `package.json` on a pull-request branch in relatio
 | Access                 | Jobs used             | Level    | Reason                                                                            | Conditions |
 | ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- | ---------- |
 | `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` | N/A        |
-| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                      | N/A        |
+| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                     | N/A        |
 
 #### Secrets
 
@@ -84,7 +84,7 @@ Synchronises the version in a `pyproject.toml` on a pull-request branch in relat
 | Access                 | Jobs used             | Level    | Reason                                                                            | Conditions |
 | ---------------------- | --------------------- | -------- | --------------------------------------------------------------------------------- | ---------- |
 | `contents: write`      | `synchronise-version` | Workflow | To POST commits against a pull request; required by `planetscale@ghcommit-action` | N/A        |
-| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                      | N/A        |
+| `pull-requests: write` | `synchronise-version` | Workflow | To use `gh pr` to DELETE labels (`v:stale`) from affected PRs                     | N/A        |
 
 #### Secrets
 
@@ -140,7 +140,7 @@ Synchronises the version in `pyproject.toml` for all open pull requests that hav
 | `contents: read`       | `find-pull-requests`        | Job   | To GET repository contents                                                                    | N/A        |
 | `pull-requests: read`  | `find-pull-requests`        | Job   | To GET open pull requests                                                                     | N/A        |
 | `contents: write`      | `synchronise-pull-requests` | Job   | To invoke `synchronise-pr-version-poetry.yml` and POST commits against all open pull requests | N/A        |
-| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs         | N/A        |
+| `pull-requests: write` | `synchronise-pull-requests` | Job   | To use `gh pr` in the upstream workflow to DELETE labels (`v:stale`) from affected PRs        | N/A        |
 
 #### Secrets
 
@@ -157,13 +157,13 @@ Builds a Docker container and optionally pushes it to GitHub Container Registry 
 
 #### Inputs
 
-| Input            | Type    | Description                                                                                                            | Default                     | Required |
+| Input            | Type    | Description                                                                                                           | Default                     | Required |
 | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------- | -------- |
 | build_args       | string  | Build arguments to pass to Docker build                                                                               | `""`                        | false    |
 | env_vars         | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                        | false    |
 | pull_dhi         | boolean | Whether to login to Docker Hardened Images registry before building                                                   | `false`                     | false    |
-| push_dockerhub   | boolean | Whether to push the built image to DockerHub                                                                           | `false`                     | false    |
-| push_ghcr        | boolean | Whether to push the built image to GHCR                                                                                | `false`                     | false    |
+| push_dockerhub   | boolean | Whether to push the built image to DockerHub                                                                          | `false`                     | false    |
+| push_ghcr        | boolean | Whether to push the built image to GHCR                                                                               | `false`                     | false    |
 | docker_platforms | string  | Specifies architectures to build the container for                                                                    | `"linux/amd64,linux/arm64"` | false    |
 | docker_file      | string  | Dockerfile to be used for building the container                                                                      | `Dockerfile`                | false    |
 
@@ -313,23 +313,23 @@ For backwards compatibility, the legacy filename [.github/workflows/generate-sbo
 
 #### Inputs
 
-| Input                  | Type    | Description                                                                                                                                | Default                               | Required |
-| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | -------- |
-| dtrack_project_name    | string  | A project name to use within Dependency Track                                                                                              | `${{ github.event.repository.name }}` | false    |
-| enable_check_version   | boolean | An option to enable the use of the digicatapult/check-version action                                                                       | `false`                               | false    |
-| enable_dtrack_project  | boolean | An option to enable the use of Dependency Track                                                                                            | `false`                               | false    |
-| package_manager        | string  | Package manager for version detection. Options: `npm`, `poetry`                                                                            | `npm`                                 | false    |
-| env_vars               | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                  | false    |
-| node_version           | string  | The node version to use                                                                                                                    | `24.x`                                | false    |
-| python_version         | string  | The Python version to use (for Poetry / `cdxgen` SBOMs)                                                                                    | `3.14`                                | false    |
-| sbom_tool              | string  | SBOM generation tool to use. Options: `@cyclonedx/cyclonedx-npm`, `@cyclonedx/cdxgen`                                                       | `@cyclonedx/cyclonedx-npm`            | false    |
-| sbom_format            | string  | SBOM output format. Options: `json`, `xml`                                                                                                 | `json`                                | false    |
-| sbom_output_file       | string  | Custom output filename. Defaults to `{repo-name}.cdx.{format}`                                                                             | `""`                                  | false    |
-| npm_build_command      | string  | Optional build command to run before generating SBOM                                                                                       | `""`                                  | false    |
-| additional_args        | string  | Additional arguments to pass to the SBOM generation tool                                                                                   | `""`                                  | false    |
-| install_python_deps    | boolean | Install Python dependencies before SBOM generation                                                                                         | `false`                               | false    |
-| python_install_command | string  | Optional custom command to install Python dependencies                                                                                     | `""`                                  | false    |
-| upload_artifact        | boolean | Whether to upload the SBOM as a workflow artifact                                                                                          | `true`                                | false    |
+| Input                  | Type    | Description                                                                                                                               | Default                               | Required |
+| ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------- |
+| dtrack_project_name    | string  | A project name to use within Dependency Track                                                                                             | `${{ github.event.repository.name }}` | false    |
+| enable_check_version   | boolean | An option to enable the use of the digicatapult/check-version action                                                                      | `false`                               | false    |
+| enable_dtrack_project  | boolean | An option to enable the use of Dependency Track                                                                                           | `false`                               | false    |
+| package_manager        | string  | Package manager for version detection. Options: `npm`, `poetry`                                                                           | `npm`                                 | false    |
+| env_vars               | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                  | false    |
+| node_version           | string  | The node version to use                                                                                                                   | `24.x`                                | false    |
+| python_version         | string  | The Python version to use (for Poetry / `cdxgen` SBOMs)                                                                                   | `3.14`                                | false    |
+| sbom_tool              | string  | SBOM generation tool to use. Options: `@cyclonedx/cyclonedx-npm`, `@cyclonedx/cdxgen`                                                     | `@cyclonedx/cyclonedx-npm`            | false    |
+| sbom_format            | string  | SBOM output format. Options: `json`, `xml`                                                                                                | `json`                                | false    |
+| sbom_output_file       | string  | Custom output filename. Defaults to `{repo-name}.cdx.{format}`                                                                            | `""`                                  | false    |
+| npm_build_command      | string  | Optional build command to run before generating SBOM                                                                                      | `""`                                  | false    |
+| additional_args        | string  | Additional arguments to pass to the SBOM generation tool                                                                                  | `""`                                  | false    |
+| install_python_deps    | boolean | Install Python dependencies before SBOM generation                                                                                        | `false`                               | false    |
+| python_install_command | string  | Optional custom command to install Python dependencies                                                                                    | `""`                                  | false    |
+| upload_artifact        | boolean | Whether to upload the SBOM as a workflow artifact                                                                                         | `true`                                | false    |
 
 #### Permissions
 
@@ -369,18 +369,18 @@ Runs static analysis for Poetry projects (default matrix includes `pylint`, `bla
 
 #### Inputs
 
-| Input                    | Type    | Description                                                                                                                                | Default                                                                           | Required |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | -------- |
-| enable_semgrep_action    | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                            | `true`                                                                            | false    |
-| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Action, scanning for exposed secrets                                                               | `false`                                                                           | false    |
-| env_vars                 | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                                                              | false    |
-| python_version           | string  | The Python version to use                                                                                                                  | `3.14`                                                                            | false    |
-| working_directory        | string  | The working directory to run the checks from                                                                                               | `.`                                                                               | false    |
-| matrix_commands          | string  | A JSON array of commands to run in the static checks matrix, each executed via `poetry run`                                                | `["pylint app", "black --check .", "ruff check .", "mypy app/", "bandit -r app"]` | false    |
-| semgrep_extra_args       | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                         | `'--config="p/default"'`                                                          | false    |
-| semgrep_sarif_path       | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                        | `semgrep.sarif`                                                                   | false    |
-| semgrep_upload_type      | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips  | `sarif`                                                                           | false    |
-| trufflehog_extra_args    | string  | Extra arguments to be passed to the TruffleHog CLI                                                                                         | `--results=verified,unknown`                                                      | false    |
+| Input                    | Type    | Description                                                                                                                               | Default                                                                           | Required |
+| ------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------- |
+| enable_semgrep_action    | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | `true`                                                                            | false    |
+| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Action, scanning for exposed secrets                                                              | `false`                                                                           | false    |
+| env_vars                 | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                                                              | false    |
+| python_version           | string  | The Python version to use                                                                                                                 | `3.14`                                                                            | false    |
+| working_directory        | string  | The working directory to run the checks from                                                                                              | `.`                                                                               | false    |
+| matrix_commands          | string  | A JSON array of commands to run in the static checks matrix, each executed via `poetry run`                                               | `["pylint app", "black --check .", "ruff check .", "mypy app/", "bandit -r app"]` | false    |
+| semgrep_extra_args       | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'`                                                          | false    |
+| semgrep_sarif_path       | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`                                                                   | false    |
+| semgrep_upload_type      | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips | `sarif`                                                                           | false    |
+| trufflehog_extra_args    | string  | Extra arguments to be passed to the TruffleHog CLI                                                                                        | `--results=verified,unknown`                                                      | false    |
 
 #### Permissions
 
@@ -406,19 +406,19 @@ Runs unit/integration tests for Poetry projects using pytest and compares covera
 
 #### Inputs
 
-| Input               | Type    | Description                                                                                                                                | Default                                | Required |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | -------- |
-| env_vars            | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                   | false    |
-| pre_test_command    | string  | Optional command to execute before the main test command                                                                                   | `""`                                   | false    |
-| pull_ghcr           | boolean | Whether to login to GitHub Container Registry before docker compose                                                                        | `false`                                | false    |
-| docker_compose_file | string  | The Docker Compose file to use for setting up dependencies                                                                                  | `docker-compose.yml`                   | false    |
-| python_version      | string  | The Python version to use                                                                                                                  | `3.14`                                 | false    |
-| working_directory   | string  | The working directory to run the tests from                                                                                                | `.`                                    | false    |
-| tests               | string  | JSON array of test paths to run with pytest                                                                                                | `["tests/unit", "tests/integration"]`  | false    |
-| pytest_args         | string  | Extra arguments to pass to pytest                                                                                                           | `-v -s`                                | false    |
-| coverage            | boolean | Whether to collect and report code coverage                                                                                                | `true`                                 | false    |
-| coverage_fail_under | number  | Fail the run if coverage for a test group falls below this percentage                                                                      | `50`                                   | false    |
-| coverage_max_drop   | number  | Fail the run if coverage for a test group drops more than this many percentage points relative to `main`                                   | `0`                                    | false    |
+| Input               | Type    | Description                                                                                                                               | Default                               | Required |
+| ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------- |
+| env_vars            | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                  | false    |
+| pre_test_command    | string  | Optional command to execute before the main test command                                                                                  | `""`                                  | false    |
+| pull_ghcr           | boolean | Whether to login to GitHub Container Registry before docker compose                                                                       | `false`                               | false    |
+| docker_compose_file | string  | The Docker Compose file to use for setting up dependencies                                                                                | `docker-compose.yml`                  | false    |
+| python_version      | string  | The Python version to use                                                                                                                 | `3.14`                                | false    |
+| working_directory   | string  | The working directory to run the tests from                                                                                               | `.`                                   | false    |
+| tests               | string  | JSON array of test paths to run with pytest                                                                                               | `["tests/unit", "tests/integration"]` | false    |
+| pytest_args         | string  | Extra arguments to pass to pytest                                                                                                         | `-v -s`                               | false    |
+| coverage            | boolean | Whether to collect and report code coverage                                                                                               | `true`                                | false    |
+| coverage_fail_under | number  | Fail the run if coverage for a test group falls below this percentage                                                                     | `50`                                  | false    |
+| coverage_max_drop   | number  | Fail the run if coverage for a test group drops more than this many percentage points relative to `main`                                  | `0`                                   | false    |
 
 #### Permissions
 
@@ -446,17 +446,17 @@ Runs end-to-end tests for Poetry projects (optionally using `docker-compose` / `
 
 #### Inputs
 
-| Input               | Type    | Description                                                                                                                                | Default                             | Required |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | -------- |
-| env_vars            | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                                | false    |
-| pre_test_command    | string  | Optional command to execute before the main test command                                                                                   | `""`                                | false    |
-| pull_ghcr           | boolean | Whether to login to GitHub Container Registry before docker compose                                                                        | `false`                             | false    |
-| docker_compose_file | string  | The Docker Compose file used for building the testing environment                                                                          | `docker-compose.yml`                | false    |
-| python_version      | string  | The Python version to use                                                                                                                  | `3.14`                              | false    |
-| setup_node          | boolean | Whether to also set up Node.js (e.g. for projects whose E2E tests use a Node-based runner)                                                  | `false`                             | false    |
-| node_version        | string  | The node version to use when `setup_node` is enabled                                                                                       | `24.x`                              | false    |
-| working_directory   | string  | The working directory to run the tests from                                                                                                | `.`                                 | false    |
-| test_command        | string  | Command used to run E2E tests, which can be customised as needed                                                                           | `poetry run pytest tests/e2e -v -s` | false    |
+| Input               | Type    | Description                                                                                                                               | Default                             | Required |
+| ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | -------- |
+| env_vars            | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                                | false    |
+| pre_test_command    | string  | Optional command to execute before the main test command                                                                                  | `""`                                | false    |
+| pull_ghcr           | boolean | Whether to login to GitHub Container Registry before docker compose                                                                       | `false`                             | false    |
+| docker_compose_file | string  | The Docker Compose file used for building the testing environment                                                                         | `docker-compose.yml`                | false    |
+| python_version      | string  | The Python version to use                                                                                                                 | `3.14`                              | false    |
+| setup_node          | boolean | Whether to also set up Node.js (e.g. for projects whose E2E tests use a Node-based runner)                                                | `false`                             | false    |
+| node_version        | string  | The node version to use when `setup_node` is enabled                                                                                      | `24.x`                              | false    |
+| working_directory   | string  | The working directory to run the tests from                                                                                               | `.`                                 | false    |
+| test_command        | string  | Command used to run E2E tests, which can be customised as needed                                                                          | `poetry run pytest tests/e2e -v -s` | false    |
 
 #### Permissions
 
@@ -481,17 +481,17 @@ Performs configurable static analysis checks on an NPM project, such as linting,
 
 #### Inputs
 
-| Input                    | Type    | Description                                                                                                                                | Default                          | Required |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------- |
-| enable_semgrep_action    | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                            | `true`                           | false    |
-| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Actions, scanning for exposed secrets                                                              | `false`                          | false    |
-| env_vars                 | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run  | `{}`                             | false    |
-| node_version             | string  | The node version to use                                                                                                                    | `24.x`                           | false    |
-| matrix_commands          | string  | A JSON array of commands to run in the static checks matrix, each representing an NPM script defined in the package                        | `["lint", "depcheck", "check"]`  | false    |
-| semgrep_extra_args       | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                         | `'--config="p/default"'`         | false    |
-| semgrep_sarif_path       | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                        | `semgrep.sarif`                  | false    |
-| semgrep_upload_type      | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips  | `sarif`                          | false    |
-| trufflehog_extra_args    | string  | Extra arguments to be passed to the TruffleHog CLI                                                                                         | `"--results=verified,unknown"`   | false    |
+| Input                    | Type    | Description                                                                                                                               | Default                         | Required |
+| ------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | -------- |
+| enable_semgrep_action    | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | `true`                          | false    |
+| enable_trufflehog_action | boolean | An option to enable a TruffleHog GitHub Actions, scanning for exposed secrets                                                             | `false`                         | false    |
+| env_vars                 | string  | A JSON string representing environment variables in the format `key:value`; parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                            | false    |
+| node_version             | string  | The node version to use                                                                                                                   | `24.x`                          | false    |
+| matrix_commands          | string  | A JSON array of commands to run in the static checks matrix, each representing an NPM script defined in the package                       | `["lint", "depcheck", "check"]` | false    |
+| semgrep_extra_args       | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'`        | false    |
+| semgrep_sarif_path       | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`                 | false    |
+| semgrep_upload_type      | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips | `sarif`                         | false    |
+| trufflehog_extra_args    | string  | Extra arguments to be passed to the TruffleHog CLI                                                                                        | `"--results=verified,unknown"`  | false    |
 
 #### Permissions
 
@@ -523,7 +523,7 @@ Executes end-to-end (E2E) tests for an NPM project using Docker Compose, support
 
 #### Inputs
 
-| Input               | Type    | Description                                                                                                                | Default              | Required |
+| Input               | Type    | Description                                                                                                               | Default              | Required |
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------- | -------- |
 | env_vars            | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the beginning of the run | `{}`                 | false    |
 | npm_build_command   | string  | Optional command to build the application before running tests                                                            | `""`                 | false    |
@@ -561,7 +561,7 @@ Runs specified NPM tests (e.g., unit and integration tests) with optional build 
 
 #### Inputs
 
-| Input                | Type    | Description                                                                                                            | Default                            | Required |
+| Input                | Type    | Description                                                                                                           | Default                            | Required |
 | -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
 | env_vars             | string  | JSON string of environment variables in `key:value` format, parsed and added to `$GITHUB_ENV` at the start of the run | `{}`                               | false    |
 | npm_build_command    | string  | Optional command to build the application before running tests                                                        | `""`                               | false    |
@@ -649,20 +649,20 @@ Runs scanners to detect bugs, security vulnerabilities, and compliance issues, w
 
 #### Inputs
 
-| Input                 | Type    | Description                                                                                                                                | Default                  | Required |
-| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------- |
-| enable_semgrep_action | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                            | `true`                   | false    |
-| extra_args            | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                         | `'--config="p/default"'` | false    |
-| sarif_path            | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                        | `semgrep.sarif`          | false    |
-| upload_type           | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips  | `sarif`                  | false    |
+| Input                 | Type    | Description                                                                                                                               | Default                  | Required |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | -------- |
+| enable_semgrep_action | boolean | An option to enable a Semgrep CE scan for bugs, security vulnerabilities, and compliance issues                                           | `true`                   | false    |
+| extra_args            | string  | Extra arguments to be passed to the Semgrep CE CLI                                                                                        | `'--config="p/default"'` | false    |
+| sarif_path            | string  | A file path used to locate the SARIF result(s) from the Semgrep CLI                                                                       | `semgrep.sarif`          | false    |
+| upload_type           | string  | Upload format for Semgrep results; `sarif` uses the CodeQL SARIF upload action, `artefact` uses vanilla artefact upload, and `none` skips | `sarif`                  | false    |
 
 #### Permissions
 
-| Access                   | Jobs used | Level    | Reason                                                     | Conditions                   |
-| ------------------------ | --------- | -------- | ---------------------------------------------------------- | ---------------------------- |
-| `security-events: write` | `semgrep` | Workflow | To POST new code scanning alerts based on the SARIF report | `inputs.upload_type: sarif`  |
-| `contents: read`         | `semgrep` | Workflow | To GET repository contents for vulnerability scanning      | N/A                          |
-| `actions: read`          | `semgrep` | Workflow | To GET actions metadata for the scan                       | N/A                          |
+| Access                   | Jobs used | Level    | Reason                                                     | Conditions                  |
+| ------------------------ | --------- | -------- | ---------------------------------------------------------- | --------------------------- |
+| `security-events: write` | `semgrep` | Workflow | To POST new code scanning alerts based on the SARIF report | `inputs.upload_type: sarif` |
+| `contents: read`         | `semgrep` | Workflow | To GET repository contents for vulnerability scanning      | N/A                         |
+| `actions: read`          | `semgrep` | Workflow | To GET actions metadata for the scan                       | N/A                         |
 
 #### Workflow Description
 
@@ -686,13 +686,13 @@ Runs OWASP ZAP Dynamic Application Security Testing (DAST) scans against a runni
 | env_vars            | string  | JSON object of extra environment variables to inject                                                 | `{}`                               | false    |
 | docker_compose_file | string  | Docker Compose file used to bring up the application stack before scanning                           | `""`                               | false    |
 | pull_ghcr           | boolean | Log in to GitHub Container Registry before pulling images (e.g. if using private/custom proxy image) | `false`                            | false    |
-| pre_scan_command    | string  | Arbitrary shell command to start the application (e.g. `npm ci && npm start &`)                       | `""`                               | false    |
+| pre_scan_command    | string  | Arbitrary shell command to start the application (e.g. `npm ci && npm start &`)                      | `""`                               | false    |
 | target_wait_timeout | number  | Seconds to poll `target` for a successful response before failing                                    | `60`                               | false    |
 | rules_file_name     | string  | Relative path to a ZAP rules TSV file for suppressing known alerts                                   | `""`                               | false    |
 | cmd_options         | string  | Additional ZAP CLI options passed to all scan types                                                  | `""`                               | false    |
 | docker_name         | string  | Custom ZAP Docker image name; defaults to the stable ZAP image                                       | `"ghcr.io/zaproxy/zaproxy:stable"` | false    |
 | allow_issue_writing | boolean | Create or update a GitHub issue in the repository with ZAP findings; requires `issues: write`        | `false`                            | false    |
-| fail_action         | boolean | Fail the job if ZAP identifies any alerts                                                             | `false`                            | false    |
+| fail_action         | boolean | Fail the job if ZAP identifies any alerts                                                            | `false`                            | false    |
 | artifact_name       | string  | Base name for uploaded scan report artifacts; suffixed with the scan type (e.g. `zap_scan-baseline`) | `zap_scan`                         | false    |
 | api_scan_format     | string  | API definition format for the `api` scan type: `openapi`, `soap`, or `graphql`                       | `openapi`                          | false    |
 | automation_plan     | string  | File path or URL of the ZAP Automation Framework plan; required when using `automation-framework`    | `""`                               | false    |


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Documentation Update

## Linked tickets

[ENG-301](https://digicatapult.atlassian.net/browse/ENG-301)

## High level description

The README documented the NPM workflows in full but left the six Poetry-family workflows as bare one-line stubs, had no table of contents, and its field tables had drifted into several inconsistent (and in places factually wrong) conventions. This PR documents the Poetry workflows to parity, adds navigation, and standardises every table against one canonical format — correcting the docs against the actual `workflow_call` definitions in the process.

## Detailed description

**Documented the six Poetry workflows** with full `Inputs` / `Permissions` / `Secrets` / `Workflow Description` sections derived from each workflow's `workflow_call` block: `synchronise-pr-version-poetry`, `synchronise-trunk-version-poetry`, `static-checks-poetry`, `tests-poetry`, `tests-e2e-poetry` (plus the `Synchronise PR Version (Poetry)` pair).

**Added a `Contents` section** at the top of the README, grouped by purpose.

**Standardised every table to one canonical format:**
- Inputs: `Input | Type | Description | Default | Required` — bare input names, bare types, backticked defaults, `Required` taken from the YAML.
- Permissions: always include a `Conditions` column (`N/A` when unconditional). `Level` (Workflow/Job) left as-is as it reflects real scoping.
- Outputs: `Output | Type | Description`.

**Corrected documentation that disagreed with the `workflow_call` definitions:**
- `release-github` `get_sbom` default `true` → `false`
- `scan-secrets` `enable_trufflehog_action` default `false` → `true`
- `scan-secrets` `enable_trufflehog_action` / `extra_args` `Required: true` → `false`
- `static-checks-npm` `trufflehog_extra_args` `Required: true` → `false`
- `bool` → `boolean` type spelling (`static-checks-npm`, `scan-secrets`, `scan-vulns`)
- added the missing `Type` column to the `Generate SBOM` Outputs table
- added four real `Generate SBOM` inputs that were undocumented (`package_manager`, `python_version`, `install_python_deps`, `python_install_command`)

All input names, types, defaults, `Required` flags, permission scopes and job names were taken from the YAML, not inferred.

## Describe alternatives you've considered

Auto-generating these tables from each workflow's `workflow_call` block would remove the drift permanently and is the natural follow-up; this PR brings the hand-maintained docs to a single consistent baseline first.

## Operational impact

None — documentation only. No workflow definitions were changed.

## Additional context

Split into two commits: (1) document the Poetry workflows + add the Contents page, (2) standardise all tables and fix the factual errors above.


[ENG-301]: https://digicatapult.atlassian.net/browse/ENG-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ