### PR TITLE
Add migration-checks workflows (knex + Alembic)

### DIFF
--- a/.github/workflows/migration-checks-npm.yml
+++ b/.github/workflows/migration-checks-npm.yml
@@ -58,11 +58,11 @@ jobs:
     name: Resolve base and head
     runs-on: ubuntu-latest
     outputs:
-      has_base: ${{ steps.r.outputs.has_base }}
-      base_sha: ${{ steps.r.outputs.base_sha }}
-      head_sha: ${{ steps.r.outputs.head_sha }}
+      has_base: ${{ steps.resolve_refs.outputs.has_base }}
+      base_sha: ${{ steps.resolve_refs.outputs.base_sha }}
+      head_sha: ${{ steps.resolve_refs.outputs.head_sha }}
     steps:
-      - id: r
+      - id: resolve_refs
         env:
           EVENT: ${{ github.event_name }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/migration-checks-npm.yml
+++ b/.github/workflows/migration-checks-npm.yml
@@ -178,7 +178,11 @@ jobs:
           MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
         run: |
           set -euo pipefail
-          count=$(find "${MIGRATIONS_DIR}" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+          if [[ -d "${MIGRATIONS_DIR}" ]]; then
+            count=$(find "${MIGRATIONS_DIR}" -maxdepth 1 -type f | wc -l | tr -d ' ')
+          else
+            count=0
+          fi
           if [[ "${count}" -gt 0 ]]; then
             echo "has_base=true" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/migration-checks-npm.yml
+++ b/.github/workflows/migration-checks-npm.yml
@@ -1,0 +1,221 @@
+name: NPM Migration checks
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        required: false
+        type: string
+        default: 24.x
+      migrations_dir:
+        description: Path to the knex migrations directory, used by the file lint job
+        required: false
+        type: string
+        default: db/migrations
+      migrate_command:
+        description: Command that applies all outstanding migrations
+        required: false
+        type: string
+        default: npm run db:migrate
+      rollback_command:
+        description: Command that rolls back the most recent migration batch
+        required: false
+        type: string
+        default: npm run db:rollback
+      seed_command:
+        description: Seed command for the seeded-upgrade job. Empty string skips seeding.
+        required: false
+        type: string
+        default: ""
+      postgres_compose_file:
+        description: Compose file whose postgres service is started for the DB-backed jobs
+        required: false
+        type: string
+        default: docker-compose.yml
+      postgres_service:
+        description: Name of the postgres service within the compose file
+        required: false
+        type: string
+        default: postgres
+      postgres_image:
+        description: >-
+          Fallback Postgres image. When set, a container from this image is
+          started instead of the caller's compose service. Prefer the compose
+          service so the CI database version tracks what the app runs.
+        required: false
+        type: string
+        default: ""
+      db_name:
+        description: Database to create when using the postgres_image fallback
+        required: false
+        type: string
+        default: postgres
+jobs:
+  lint-migrations:
+    name: Lint migration files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Merged migrations must be immutable
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_REF}" ]]; then
+            echo "No base ref (not a pull_request event); skipping migration lint."
+            exit 0
+          fi
+          git fetch origin "${BASE_REF}" --quiet
+          changed=$(git diff --name-status --diff-filter=MRD \
+            "origin/${BASE_REF}...HEAD" -- "${MIGRATIONS_DIR}")
+          if [[ -n "${changed}" ]]; then
+            echo "Migrations already on ${BASE_REF} must not be modified, renamed, or deleted."
+            echo "Knex records applied migrations by filename; changing one desyncs every"
+            echo "database that already ran it. Add a NEW forward migration instead."
+            echo ""
+            echo "${changed}"
+            exit 1
+          fi
+          echo "No merged migrations were modified."
+      - name: New migrations must sort after existing ones
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_REF}" ]]; then
+            exit 0
+          fi
+          newest_on_base=$(git ls-tree -r --name-only "origin/${BASE_REF}" -- "${MIGRATIONS_DIR}" \
+            | xargs -r -n1 basename | sort | tail -1)
+          added=$(git diff --name-only --diff-filter=A \
+            "origin/${BASE_REF}...HEAD" -- "${MIGRATIONS_DIR}" | xargs -r -n1 basename)
+          if [[ -z "${added}" || -z "${newest_on_base}" ]]; then
+            echo "No new migrations to order-check."
+            exit 0
+          fi
+          failed=0
+          while IFS= read -r new_file; do
+            [[ -z "${new_file}" ]] && continue
+            if [[ ! "${new_file}" > "${newest_on_base}" ]]; then
+              echo "New migration ${new_file} does not sort after ${newest_on_base}."
+              echo "Knex runs migrations in filename order; one that sorts before a migration"
+              echo "already applied will run out of order on existing databases."
+              failed=1
+            fi
+          done <<< "${added}"
+          exit "${failed}"
+
+  migrate-roundtrip:
+    name: Migrate up / down / up
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+      - name: Start Postgres
+        env:
+          IMAGE: ${{ inputs.postgres_image }}
+          COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
+          SERVICE: ${{ inputs.postgres_service }}
+          DB_NAME: ${{ inputs.db_name }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${IMAGE}" ]]; then
+            echo "Starting Postgres from fallback image ${IMAGE}"
+            docker run -d --name mc-postgres \
+              -e POSTGRES_USER=postgres \
+              -e POSTGRES_PASSWORD=postgres \
+              -e POSTGRES_DB="${DB_NAME}" \
+              -p 5432:5432 "${IMAGE}"
+          else
+            echo "Starting '${SERVICE}' from ${COMPOSE_FILE}"
+            docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
+          fi
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
+              echo "Postgres is ready"
+              exit 0
+            fi
+            echo "waiting for postgres (${i})"
+            sleep 2
+          done
+          echo "Postgres did not become ready in time"
+          exit 1
+      - name: Install packages
+        run: npm ci
+      - name: Migrate up
+        run: ${{ inputs.migrate_command }}
+      - name: Roll back
+        run: ${{ inputs.rollback_command }}
+      - name: Migrate up again
+        run: ${{ inputs.migrate_command }}
+
+  seeded-upgrade:
+    name: Upgrade seeded base-branch database
+    runs-on: ubuntu-latest
+    if: ${{ github.base_ref != '' }}
+    steps:
+      # Phase 1: reconstruct the production-like starting state from the base branch.
+      - name: Check out base ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+      - name: Start Postgres
+        env:
+          IMAGE: ${{ inputs.postgres_image }}
+          COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
+          SERVICE: ${{ inputs.postgres_service }}
+          DB_NAME: ${{ inputs.db_name }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${IMAGE}" ]]; then
+            echo "Starting Postgres from fallback image ${IMAGE}"
+            docker run -d --name mc-postgres \
+              -e POSTGRES_USER=postgres \
+              -e POSTGRES_PASSWORD=postgres \
+              -e POSTGRES_DB="${DB_NAME}" \
+              -p 5432:5432 "${IMAGE}"
+          else
+            echo "Starting '${SERVICE}' from ${COMPOSE_FILE}"
+            docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
+          fi
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
+              echo "Postgres is ready"
+              exit 0
+            fi
+            echo "waiting for postgres (${i})"
+            sleep 2
+          done
+          echo "Postgres did not become ready in time"
+          exit 1
+      - name: Install packages (base ref)
+        run: npm ci
+      - name: Migrate at base ref
+        run: ${{ inputs.migrate_command }}
+      - name: Seed at base ref
+        if: ${{ inputs.seed_command != '' }}
+        run: ${{ inputs.seed_command }}
+      # Phase 2: apply only the PR's new migrations on top of the seeded data.
+      - name: Check out PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          clean: true
+      - name: Install packages (PR head)
+        run: npm ci
+      - name: Apply new migrations against seeded data
+        run: ${{ inputs.migrate_command }}

--- a/.github/workflows/migration-checks-npm.yml
+++ b/.github/workflows/migration-checks-npm.yml
@@ -50,28 +50,63 @@ on:
         type: string
         default: postgres
 jobs:
+  # Works on both pull_request and push callers. On pull_request the base/head
+  # are the PR base and head; on push (e.g. release.yml on main) they are the
+  # commit before the push and the pushed commit, so seeded-upgrade becomes a
+  # final "upgrade the previously deployed commit to this one" check.
+  resolve:
+    name: Resolve base and head
+    runs-on: ubuntu-latest
+    outputs:
+      has_base: ${{ steps.r.outputs.has_base }}
+      base_sha: ${{ steps.r.outputs.base_sha }}
+      head_sha: ${{ steps.r.outputs.head_sha }}
+    steps:
+      - id: r
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT}" == "pull_request" ]]; then
+            base="${PR_BASE}"
+            head="${PR_HEAD}"
+          else
+            base="${PUSH_BEFORE}"
+            head="${PUSH_AFTER}"
+          fi
+          if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+            echo "No base commit to compare against; lint and seeded-upgrade no-op."
+            echo "has_base=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_base=true" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "base_sha=${base}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${head}" >> "${GITHUB_OUTPUT}"
+
   lint-migrations:
     name: Lint migration files
+    needs: resolve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Merged migrations must be immutable
+        if: ${{ needs.resolve.outputs.has_base == 'true' }}
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
         run: |
           set -euo pipefail
-          if [[ -z "${BASE_REF}" ]]; then
-            echo "No base ref (not a pull_request event); skipping migration lint."
-            exit 0
-          fi
-          git fetch origin "${BASE_REF}" --quiet
           changed=$(git diff --name-status --diff-filter=MRD \
-            "origin/${BASE_REF}...HEAD" -- "${MIGRATIONS_DIR}")
+            "${BASE_SHA}...${HEAD_SHA}" -- "${MIGRATIONS_DIR}")
           if [[ -n "${changed}" ]]; then
-            echo "Migrations already on ${BASE_REF} must not be modified, renamed, or deleted."
+            echo "Migrations already present on the base must not be modified, renamed, or deleted."
             echo "Knex records applied migrations by filename; changing one desyncs every"
             echo "database that already ran it. Add a NEW forward migration instead."
             echo ""
@@ -80,18 +115,17 @@ jobs:
           fi
           echo "No merged migrations were modified."
       - name: New migrations must sort after existing ones
+        if: ${{ needs.resolve.outputs.has_base == 'true' }}
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
         run: |
           set -euo pipefail
-          if [[ -z "${BASE_REF}" ]]; then
-            exit 0
-          fi
-          newest_on_base=$(git ls-tree -r --name-only "origin/${BASE_REF}" -- "${MIGRATIONS_DIR}" \
+          newest_on_base=$(git ls-tree -r --name-only "${BASE_SHA}" -- "${MIGRATIONS_DIR}" \
             | xargs -r -n1 basename | sort | tail -1)
           added=$(git diff --name-only --diff-filter=A \
-            "origin/${BASE_REF}...HEAD" -- "${MIGRATIONS_DIR}" | xargs -r -n1 basename)
+            "${BASE_SHA}...${HEAD_SHA}" -- "${MIGRATIONS_DIR}" | xargs -r -n1 basename)
           if [[ -z "${added}" || -z "${newest_on_base}" ]]; then
             echo "No new migrations to order-check."
             exit 0
@@ -158,21 +192,23 @@ jobs:
         run: ${{ inputs.migrate_command }}
 
   seeded-upgrade:
-    name: Upgrade seeded base-branch database
+    name: Upgrade seeded base database
+    needs: resolve
+    if: ${{ needs.resolve.outputs.has_base == 'true' }}
     runs-on: ubuntu-latest
-    if: ${{ github.base_ref != '' }}
     steps:
-      # Phase 1: reconstruct the production-like starting state from the base branch.
-      - name: Check out base ref
+      # Phase 1: reconstruct the production-like starting state from the base commit.
+      - name: Check out base
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ needs.resolve.outputs.base_sha }}
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
       # A repo introducing its first migration has nothing to upgrade from, so
       # the rest of this job is skipped rather than failing on a missing setup.
-      - name: Detect base-ref migrations
+      - name: Detect base migrations
         id: base
         env:
           MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
@@ -184,13 +220,13 @@ jobs:
             count=0
           fi
           if [[ "${count}" -gt 0 ]]; then
-            echo "has_base=true" >> "${GITHUB_OUTPUT}"
+            echo "has_migrations=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "No migrations on ${{ github.base_ref }}; nothing to upgrade from. Skipping."
-            echo "has_base=false" >> "${GITHUB_OUTPUT}"
+            echo "No migrations on the base commit; nothing to upgrade from. Skipping."
+            echo "has_migrations=false" >> "${GITHUB_OUTPUT}"
           fi
       - name: Start Postgres
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         env:
           IMAGE: ${{ inputs.postgres_image }}
           COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
@@ -210,7 +246,7 @@ jobs:
             docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
           fi
       - name: Wait for Postgres
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
@@ -223,25 +259,25 @@ jobs:
           done
           echo "Postgres did not become ready in time"
           exit 1
-      - name: Install packages (base ref)
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      - name: Install packages (base)
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         run: npm ci
-      - name: Migrate at base ref
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      - name: Migrate at base
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         run: ${{ inputs.migrate_command }}
-      - name: Seed at base ref
-        if: ${{ steps.base.outputs.has_base == 'true' && inputs.seed_command != '' }}
+      - name: Seed at base
+        if: ${{ steps.base.outputs.has_migrations == 'true' && inputs.seed_command != '' }}
         run: ${{ inputs.seed_command }}
-      # Phase 2: apply only the PR's new migrations on top of the seeded data.
-      - name: Check out PR head
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      # Phase 2: apply only the new migrations on top of the seeded data.
+      - name: Check out head
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.resolve.outputs.head_sha }}
           clean: true
-      - name: Install packages (PR head)
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      - name: Install packages (head)
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         run: npm ci
       - name: Apply new migrations against seeded data
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+        if: ${{ steps.base.outputs.has_migrations == 'true' }}
         run: ${{ inputs.migrate_command }}

--- a/.github/workflows/migration-checks-npm.yml
+++ b/.github/workflows/migration-checks-npm.yml
@@ -170,7 +170,23 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
+      # A repo introducing its first migration has nothing to upgrade from, so
+      # the rest of this job is skipped rather than failing on a missing setup.
+      - name: Detect base-ref migrations
+        id: base
+        env:
+          MIGRATIONS_DIR: ${{ inputs.migrations_dir }}
+        run: |
+          set -euo pipefail
+          count=$(find "${MIGRATIONS_DIR}" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+          if [[ "${count}" -gt 0 ]]; then
+            echo "has_base=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "No migrations on ${{ github.base_ref }}; nothing to upgrade from. Skipping."
+            echo "has_base=false" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Start Postgres
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         env:
           IMAGE: ${{ inputs.postgres_image }}
           COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
@@ -190,6 +206,7 @@ jobs:
             docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
           fi
       - name: Wait for Postgres
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
@@ -203,19 +220,24 @@ jobs:
           echo "Postgres did not become ready in time"
           exit 1
       - name: Install packages (base ref)
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: npm ci
       - name: Migrate at base ref
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: ${{ inputs.migrate_command }}
       - name: Seed at base ref
-        if: ${{ inputs.seed_command != '' }}
+        if: ${{ steps.base.outputs.has_base == 'true' && inputs.seed_command != '' }}
         run: ${{ inputs.seed_command }}
       # Phase 2: apply only the PR's new migrations on top of the seeded data.
       - name: Check out PR head
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           clean: true
       - name: Install packages (PR head)
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: npm ci
       - name: Apply new migrations against seeded data
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: ${{ inputs.migrate_command }}

--- a/.github/workflows/migration-checks-poetry.yml
+++ b/.github/workflows/migration-checks-poetry.yml
@@ -58,11 +58,11 @@ jobs:
     name: Resolve base and head
     runs-on: ubuntu-latest
     outputs:
-      has_base: ${{ steps.r.outputs.has_base }}
-      base_sha: ${{ steps.r.outputs.base_sha }}
-      head_sha: ${{ steps.r.outputs.head_sha }}
+      has_base: ${{ steps.resolve_refs.outputs.has_base }}
+      base_sha: ${{ steps.resolve_refs.outputs.base_sha }}
+      head_sha: ${{ steps.resolve_refs.outputs.head_sha }}
     steps:
-      - id: r
+      - id: resolve_refs
         env:
           EVENT: ${{ github.event_name }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/migration-checks-poetry.yml
+++ b/.github/workflows/migration-checks-poetry.yml
@@ -50,28 +50,63 @@ on:
         type: string
         default: postgres
 jobs:
+  # Works on both pull_request and push callers. On pull_request the base/head
+  # are the PR base and head; on push (e.g. release.yml on main) they are the
+  # commit before the push and the pushed commit, so seeded-upgrade becomes a
+  # final "upgrade the previously deployed commit to this one" check.
+  resolve:
+    name: Resolve base and head
+    runs-on: ubuntu-latest
+    outputs:
+      has_base: ${{ steps.r.outputs.has_base }}
+      base_sha: ${{ steps.r.outputs.base_sha }}
+      head_sha: ${{ steps.r.outputs.head_sha }}
+    steps:
+      - id: r
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT}" == "pull_request" ]]; then
+            base="${PR_BASE}"
+            head="${PR_HEAD}"
+          else
+            base="${PUSH_BEFORE}"
+            head="${PUSH_AFTER}"
+          fi
+          if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+            echo "No base commit to compare against; immutability lint and seeded-upgrade no-op."
+            echo "has_base=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_base=true" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "base_sha=${base}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${head}" >> "${GITHUB_OUTPUT}"
+
   lint-migrations:
     name: Lint migration files
+    needs: resolve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Merged revisions must be immutable
+        if: ${{ needs.resolve.outputs.has_base == 'true' }}
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
           VERSIONS_DIR: ${{ inputs.versions_dir }}
         run: |
           set -euo pipefail
-          if [[ -z "${BASE_REF}" ]]; then
-            echo "No base ref (not a pull_request event); skipping revision lint."
-            exit 0
-          fi
-          git fetch origin "${BASE_REF}" --quiet
           changed=$(git diff --name-status --diff-filter=MRD \
-            "origin/${BASE_REF}...HEAD" -- "${VERSIONS_DIR}")
+            "${BASE_SHA}...${HEAD_SHA}" -- "${VERSIONS_DIR}")
           if [[ -n "${changed}" ]]; then
-            echo "Alembic revisions already on ${BASE_REF} must not be modified, renamed, or deleted."
+            echo "Alembic revisions already present on the base must not be modified, renamed, or deleted."
             echo "Editing a merged revision (especially its down_revision) breaks the chain for"
             echo "every database that already applied it. Add a NEW revision instead."
             echo ""
@@ -87,6 +122,8 @@ jobs:
           cache: poetry
       - name: Install packages
         run: poetry install --no-interaction --no-ansi
+      # Not a base comparison, so this runs on every event including a repo's
+      # first revision: the current tree must resolve to exactly one head.
       - name: Revision graph must have a single head
         run: |
           set -euo pipefail
@@ -153,15 +190,17 @@ jobs:
         run: ${{ inputs.migrate_command }}
 
   seeded-upgrade:
-    name: Upgrade seeded base-branch database
+    name: Upgrade seeded base database
+    needs: resolve
+    if: ${{ needs.resolve.outputs.has_base == 'true' }}
     runs-on: ubuntu-latest
-    if: ${{ github.base_ref != '' }}
     steps:
-      # Phase 1: reconstruct the production-like starting state from the base branch.
-      - name: Check out base ref
+      # Phase 1: reconstruct the production-like starting state from the base commit.
+      - name: Check out base
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ needs.resolve.outputs.base_sha }}
+          fetch-depth: 0
       - name: Install poetry
         run: pipx install poetry
       - uses: actions/setup-python@v6
@@ -170,7 +209,7 @@ jobs:
           cache: poetry
       # A repo introducing its first revision has nothing to upgrade from, so
       # the rest of this job is skipped rather than failing on a missing setup.
-      - name: Detect base-ref revisions
+      - name: Detect base revisions
         id: base
         env:
           VERSIONS_DIR: ${{ inputs.versions_dir }}
@@ -182,13 +221,13 @@ jobs:
             count=0
           fi
           if [[ "${count}" -gt 0 ]]; then
-            echo "has_base=true" >> "${GITHUB_OUTPUT}"
+            echo "has_revisions=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "No revisions on ${{ github.base_ref }}; nothing to upgrade from. Skipping."
-            echo "has_base=false" >> "${GITHUB_OUTPUT}"
+            echo "No revisions on the base commit; nothing to upgrade from. Skipping."
+            echo "has_revisions=false" >> "${GITHUB_OUTPUT}"
           fi
       - name: Start Postgres
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         env:
           IMAGE: ${{ inputs.postgres_image }}
           COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
@@ -208,7 +247,7 @@ jobs:
             docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
           fi
       - name: Wait for Postgres
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
@@ -221,25 +260,25 @@ jobs:
           done
           echo "Postgres did not become ready in time"
           exit 1
-      - name: Install packages (base ref)
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      - name: Install packages (base)
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         run: poetry install --no-interaction --no-ansi
-      - name: Upgrade to head at base ref
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      - name: Upgrade to head at base
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         run: ${{ inputs.migrate_command }}
-      - name: Seed at base ref
-        if: ${{ steps.base.outputs.has_base == 'true' && inputs.seed_command != '' }}
+      - name: Seed at base
+        if: ${{ steps.base.outputs.has_revisions == 'true' && inputs.seed_command != '' }}
         run: ${{ inputs.seed_command }}
-      # Phase 2: apply only the PR's new revisions on top of the seeded data.
-      - name: Check out PR head
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      # Phase 2: apply only the new revisions on top of the seeded data.
+      - name: Check out head
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.resolve.outputs.head_sha }}
           clean: true
-      - name: Install packages (PR head)
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+      - name: Install packages (head)
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         run: poetry install --no-interaction --no-ansi
       - name: Apply new revisions against seeded data
-        if: ${{ steps.base.outputs.has_base == 'true' }}
+        if: ${{ steps.base.outputs.has_revisions == 'true' }}
         run: ${{ inputs.migrate_command }}

--- a/.github/workflows/migration-checks-poetry.yml
+++ b/.github/workflows/migration-checks-poetry.yml
@@ -176,7 +176,11 @@ jobs:
           VERSIONS_DIR: ${{ inputs.versions_dir }}
         run: |
           set -euo pipefail
-          count=$(find "${VERSIONS_DIR}" -maxdepth 1 -type f -name '*.py' 2>/dev/null | wc -l | tr -d ' ')
+          if [[ -d "${VERSIONS_DIR}" ]]; then
+            count=$(find "${VERSIONS_DIR}" -maxdepth 1 -type f -name '*.py' | wc -l | tr -d ' ')
+          else
+            count=0
+          fi
           if [[ "${count}" -gt 0 ]]; then
             echo "has_base=true" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/migration-checks-poetry.yml
+++ b/.github/workflows/migration-checks-poetry.yml
@@ -1,0 +1,219 @@
+name: Poetry Migration checks
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        required: false
+        type: string
+        default: "3.14"
+      versions_dir:
+        description: Path to the alembic versions directory, used by the file lint job
+        required: false
+        type: string
+        default: alembic/versions
+      migrate_command:
+        description: Command that applies all outstanding revisions
+        required: false
+        type: string
+        default: poetry run alembic upgrade head
+      rollback_command:
+        description: Command that downgrades to the base (empty) revision
+        required: false
+        type: string
+        default: poetry run alembic downgrade base
+      seed_command:
+        description: Seed command for the seeded-upgrade job. Empty string skips seeding.
+        required: false
+        type: string
+        default: ""
+      postgres_compose_file:
+        description: Compose file whose postgres service is started for the DB-backed jobs
+        required: false
+        type: string
+        default: docker-compose.yml
+      postgres_service:
+        description: Name of the postgres service within the compose file
+        required: false
+        type: string
+        default: postgres
+      postgres_image:
+        description: >-
+          Fallback Postgres image. When set, a container from this image is
+          started instead of the caller's compose service. Prefer the compose
+          service so the CI database version tracks what the app runs.
+        required: false
+        type: string
+        default: ""
+      db_name:
+        description: Database to create when using the postgres_image fallback
+        required: false
+        type: string
+        default: postgres
+jobs:
+  lint-migrations:
+    name: Lint migration files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Merged revisions must be immutable
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          VERSIONS_DIR: ${{ inputs.versions_dir }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_REF}" ]]; then
+            echo "No base ref (not a pull_request event); skipping revision lint."
+            exit 0
+          fi
+          git fetch origin "${BASE_REF}" --quiet
+          changed=$(git diff --name-status --diff-filter=MRD \
+            "origin/${BASE_REF}...HEAD" -- "${VERSIONS_DIR}")
+          if [[ -n "${changed}" ]]; then
+            echo "Alembic revisions already on ${BASE_REF} must not be modified, renamed, or deleted."
+            echo "Editing a merged revision (especially its down_revision) breaks the chain for"
+            echo "every database that already applied it. Add a NEW revision instead."
+            echo ""
+            echo "${changed}"
+            exit 1
+          fi
+          echo "No merged revisions were modified."
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+          cache: poetry
+      - name: Install packages
+        run: poetry install --no-interaction --no-ansi
+      - name: Revision graph must have a single head
+        run: |
+          set -euo pipefail
+          heads=$(poetry run alembic heads 2>/dev/null | grep -c '(head)' || true)
+          if [[ "${heads}" -ne 1 ]]; then
+            echo "Revision graph has ${heads} heads; expected exactly 1."
+            echo "A second revision merged since this branch was cut. Rebase and point your"
+            echo "revision's down_revision at the new head so the graph is linear again."
+            poetry run alembic heads || true
+            exit 1
+          fi
+          echo "Revision graph has a single head."
+
+  migrate-roundtrip:
+    name: Upgrade / downgrade / upgrade
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+          cache: poetry
+      - name: Start Postgres
+        env:
+          IMAGE: ${{ inputs.postgres_image }}
+          COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
+          SERVICE: ${{ inputs.postgres_service }}
+          DB_NAME: ${{ inputs.db_name }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${IMAGE}" ]]; then
+            echo "Starting Postgres from fallback image ${IMAGE}"
+            docker run -d --name mc-postgres \
+              -e POSTGRES_USER=postgres \
+              -e POSTGRES_PASSWORD=postgres \
+              -e POSTGRES_DB="${DB_NAME}" \
+              -p 5432:5432 "${IMAGE}"
+          else
+            echo "Starting '${SERVICE}' from ${COMPOSE_FILE}"
+            docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
+          fi
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
+              echo "Postgres is ready"
+              exit 0
+            fi
+            echo "waiting for postgres (${i})"
+            sleep 2
+          done
+          echo "Postgres did not become ready in time"
+          exit 1
+      - name: Install packages
+        run: poetry install --no-interaction --no-ansi
+      - name: Upgrade to head
+        run: ${{ inputs.migrate_command }}
+      - name: Downgrade to base
+        run: ${{ inputs.rollback_command }}
+      - name: Upgrade to head again
+        run: ${{ inputs.migrate_command }}
+
+  seeded-upgrade:
+    name: Upgrade seeded base-branch database
+    runs-on: ubuntu-latest
+    if: ${{ github.base_ref != '' }}
+    steps:
+      # Phase 1: reconstruct the production-like starting state from the base branch.
+      - name: Check out base ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+          cache: poetry
+      - name: Start Postgres
+        env:
+          IMAGE: ${{ inputs.postgres_image }}
+          COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
+          SERVICE: ${{ inputs.postgres_service }}
+          DB_NAME: ${{ inputs.db_name }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${IMAGE}" ]]; then
+            echo "Starting Postgres from fallback image ${IMAGE}"
+            docker run -d --name mc-postgres \
+              -e POSTGRES_USER=postgres \
+              -e POSTGRES_PASSWORD=postgres \
+              -e POSTGRES_DB="${DB_NAME}" \
+              -p 5432:5432 "${IMAGE}"
+          else
+            echo "Starting '${SERVICE}' from ${COMPOSE_FILE}"
+            docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
+          fi
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; then
+              echo "Postgres is ready"
+              exit 0
+            fi
+            echo "waiting for postgres (${i})"
+            sleep 2
+          done
+          echo "Postgres did not become ready in time"
+          exit 1
+      - name: Install packages (base ref)
+        run: poetry install --no-interaction --no-ansi
+      - name: Upgrade to head at base ref
+        run: ${{ inputs.migrate_command }}
+      - name: Seed at base ref
+        if: ${{ inputs.seed_command != '' }}
+        run: ${{ inputs.seed_command }}
+      # Phase 2: apply only the PR's new revisions on top of the seeded data.
+      - name: Check out PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          clean: true
+      - name: Install packages (PR head)
+        run: poetry install --no-interaction --no-ansi
+      - name: Apply new revisions against seeded data
+        run: ${{ inputs.migrate_command }}

--- a/.github/workflows/migration-checks-poetry.yml
+++ b/.github/workflows/migration-checks-poetry.yml
@@ -168,7 +168,23 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
           cache: poetry
+      # A repo introducing its first revision has nothing to upgrade from, so
+      # the rest of this job is skipped rather than failing on a missing setup.
+      - name: Detect base-ref revisions
+        id: base
+        env:
+          VERSIONS_DIR: ${{ inputs.versions_dir }}
+        run: |
+          set -euo pipefail
+          count=$(find "${VERSIONS_DIR}" -maxdepth 1 -type f -name '*.py' 2>/dev/null | wc -l | tr -d ' ')
+          if [[ "${count}" -gt 0 ]]; then
+            echo "has_base=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "No revisions on ${{ github.base_ref }}; nothing to upgrade from. Skipping."
+            echo "has_base=false" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Start Postgres
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         env:
           IMAGE: ${{ inputs.postgres_image }}
           COMPOSE_FILE: ${{ inputs.postgres_compose_file }}
@@ -188,6 +204,7 @@ jobs:
             docker compose -f "${COMPOSE_FILE}" up -d --wait "${SERVICE}"
           fi
       - name: Wait for Postgres
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
@@ -201,19 +218,24 @@ jobs:
           echo "Postgres did not become ready in time"
           exit 1
       - name: Install packages (base ref)
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: poetry install --no-interaction --no-ansi
       - name: Upgrade to head at base ref
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: ${{ inputs.migrate_command }}
       - name: Seed at base ref
-        if: ${{ inputs.seed_command != '' }}
+        if: ${{ steps.base.outputs.has_base == 'true' && inputs.seed_command != '' }}
         run: ${{ inputs.seed_command }}
       # Phase 2: apply only the PR's new revisions on top of the seeded data.
       - name: Check out PR head
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           clean: true
       - name: Install packages (PR head)
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: poetry install --no-interaction --no-ansi
       - name: Apply new revisions against seeded data
+        if: ${{ steps.base.outputs.has_base == 'true' }}
         run: ${{ inputs.migrate_command }}

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Shared github workflows created by the `digicatapult` organisation.
 - [Poetry Static checks](#poetry-static-checks-examples)
 - [Poetry Tests](#poetry-tests-examples)
 - [Poetry E2E tests](#poetry-e2e-tests-examples)
+- [Poetry Migration Checks](#poetry-migration-checks-examples)
 - [NPM Static Checks](#npm-static-checks-examples)
 - [NPM E2E Tests](#npm-e2e-tests-examples)
 - [NPM Tests](#npm-tests-examples)
+- [NPM Migration Checks](#npm-migration-checks-examples)
 
 **Security & analysis**
 
@@ -618,6 +620,58 @@ This GitHub Actions workflow runs a series of NPM test commands in a matrix stra
 8. **Fail if Under Thresholds**: Runs c8's threshold check, failing the workflow if coverage is below configured thresholds.
 
 This workflow provides a comprehensive testing and coverage solution with branch comparison, custom build commands, Docker-based dependencies, and detailed coverage reporting including trend analysis.
+
+### [NPM Migration Checks](.github/workflows/migration-checks-npm.yml) ([examples](examples/migration-checks.md))
+
+Guards knex database migrations on a pull request. Our other CI only ever migrates an empty database, and migrations run at container startup in production, so a migration that only fails against existing data (for example an `UPDATE` that violates a still-active `CHECK` constraint) is first exercised at deploy time. This workflow moves that failure into CI. It runs three jobs: a file lint (merged migrations are immutable, and new migrations must sort after existing ones), an up/down/up rollback roundtrip, and a seeded-upgrade job that migrates and seeds a database at the base ref, then applies only the PR's new migrations on top. Postgres is started from the caller's own compose service by default so the CI version tracks what the application runs, with an image fallback.
+
+This workflow must be called on a `pull_request` event; the lint and seeded-upgrade jobs compare against `github.base_ref` and self-skip when it is empty.
+
+#### Inputs
+
+| Input                 | Type   | Description                                                                                                | Default              | Required |
+| --------------------- | ------ | --------------------------------------------------------------------------------------------------------- | -------------------- | -------- |
+| node_version          | string | The node version to use                                                                                   | `24.x`               | false    |
+| migrations_dir        | string | Path to the knex migrations directory, used by the file lint job                                          | `db/migrations`      | false    |
+| migrate_command       | string | Command that applies all outstanding migrations                                                           | `npm run db:migrate` | false    |
+| rollback_command      | string | Command that rolls back the most recent migration batch                                                   | `npm run db:rollback`| false    |
+| seed_command          | string | Seed command for the seeded-upgrade job. Empty string skips seeding                                       | `""`                 | false    |
+| postgres_compose_file | string | Compose file whose postgres service is started for the DB-backed jobs                                     | `docker-compose.yml` | false    |
+| postgres_service      | string | Name of the postgres service within the compose file                                                     | `postgres`           | false    |
+| postgres_image        | string | Fallback Postgres image; when set, a container from this image is used instead of the compose service     | `""`                 | false    |
+| db_name               | string | Database to create when using the `postgres_image` fallback                                               | `postgres`           | false    |
+
+#### Permissions
+
+| Access           | Jobs used                                             | Level    | Reason                                                             | Conditions |
+| ---------------- | ----------------------------------------------------- | -------- | ------------------------------------------------------------------ | ---------- |
+| `contents: read` | `lint-migrations`, `migrate-roundtrip`, `seeded-upgrade` | Workflow | To GET repository contents and check out the base ref and PR head | N/A        |
+
+### [Poetry Migration Checks](.github/workflows/migration-checks-poetry.yml) ([examples](examples/migration-checks-poetry.md))
+
+The Alembic sibling of [NPM Migration Checks](#npm-migration-checks-examples), for Poetry projects. Same three jobs and the same rationale, with two mechanical differences: rollbacks use `alembic downgrade base`, and the file lint enforces that the revision graph has exactly one head (Alembic orders revisions by `down_revision`, not filename, so multiple heads are the equivalent of a knex "reorder" hazard) rather than a filename sort.
+
+This workflow must be called on a `pull_request` event; the lint and seeded-upgrade jobs compare against `github.base_ref` and self-skip when it is empty.
+
+#### Inputs
+
+| Input                 | Type   | Description                                                                                            | Default                          | Required |
+| --------------------- | ------ | ----------------------------------------------------------------------------------------------------- | -------------------------------- | -------- |
+| python_version        | string | The python version to use                                                                             | `3.14`                           | false    |
+| versions_dir          | string | Path to the alembic versions directory, used by the file lint job                                     | `alembic/versions`               | false    |
+| migrate_command       | string | Command that applies all outstanding revisions                                                        | `poetry run alembic upgrade head`| false    |
+| rollback_command      | string | Command that downgrades to the base (empty) revision                                                  | `poetry run alembic downgrade base`| false  |
+| seed_command          | string | Seed command for the seeded-upgrade job. Empty string skips seeding                                   | `""`                             | false    |
+| postgres_compose_file | string | Compose file whose postgres service is started for the DB-backed jobs                                 | `docker-compose.yml`             | false    |
+| postgres_service      | string | Name of the postgres service within the compose file                                                 | `postgres`                       | false    |
+| postgres_image        | string | Fallback Postgres image; when set, a container from this image is used instead of the compose service | `""`                             | false    |
+| db_name               | string | Database to create when using the `postgres_image` fallback                                           | `postgres`                       | false    |
+
+#### Permissions
+
+| Access           | Jobs used                                             | Level    | Reason                                                             | Conditions |
+| ---------------- | ----------------------------------------------------- | -------- | ------------------------------------------------------------------ | ---------- |
+| `contents: read` | `lint-migrations`, `migrate-roundtrip`, `seeded-upgrade` | Workflow | To GET repository contents and check out the base ref and PR head | N/A        |
 
 ### [Scan Secrets](.github/workflows/scan-secrets.yml) ([examples](examples/scan-secrets.md))
 

--- a/README.md
+++ b/README.md
@@ -623,9 +623,9 @@ This workflow provides a comprehensive testing and coverage solution with branch
 
 ### [NPM Migration Checks](.github/workflows/migration-checks-npm.yml) ([examples](examples/migration-checks.md))
 
-Guards knex database migrations on a pull request. Our other CI only ever migrates an empty database, and migrations run at container startup in production, so a migration that only fails against existing data (for example an `UPDATE` that violates a still-active `CHECK` constraint) is first exercised at deploy time. This workflow moves that failure into CI. It runs three jobs: a file lint (merged migrations are immutable, and new migrations must sort after existing ones), an up/down/up rollback roundtrip, and a seeded-upgrade job that migrates and seeds a database at the base ref, then applies only the PR's new migrations on top. Postgres is started from the caller's own compose service by default so the CI version tracks what the application runs, with an image fallback.
+Guards knex database migrations. Our other CI only ever migrates an empty database, and migrations run at container startup in production, so a migration that only fails against existing data (for example an `UPDATE` that violates a still-active `CHECK` constraint) is first exercised at deploy time. This workflow moves that failure into CI. It runs three jobs: a file lint (merged migrations are immutable, and new migrations must sort after existing ones), an up/down/up rollback roundtrip, and a seeded-upgrade job that migrates and seeds a database at the base commit, then applies only the new migrations on top. Postgres is started from the caller's own compose service by default so the CI version tracks what the application runs, with an image fallback.
 
-This workflow must be called on a `pull_request` event; the lint and seeded-upgrade jobs compare against `github.base_ref` and self-skip when it is empty.
+Works on both `pull_request` and `push` callers. On `pull_request` the base and head are the PR base and head; on `push` (for example a `release.yml` on `main`) they are the commit before the push and the pushed commit, making seeded-upgrade a final pre-deploy "upgrade the previously deployed commit to this one" check. `migrate-roundtrip` runs on any event; the lint and seeded-upgrade jobs no-op when there is no base to compare against.
 
 #### Inputs
 
@@ -651,7 +651,7 @@ This workflow must be called on a `pull_request` event; the lint and seeded-upgr
 
 The Alembic sibling of [NPM Migration Checks](#npm-migration-checks-examples), for Poetry projects. Same three jobs and the same rationale, with two mechanical differences: rollbacks use `alembic downgrade base`, and the file lint enforces that the revision graph has exactly one head (Alembic orders revisions by `down_revision`, not filename, so multiple heads are the equivalent of a knex "reorder" hazard) rather than a filename sort.
 
-This workflow must be called on a `pull_request` event; the lint and seeded-upgrade jobs compare against `github.base_ref` and self-skip when it is empty.
+Works on both `pull_request` and `push` callers, the same way as the NPM variant. The single-head lint and `migrate-roundtrip` run on any event; the immutability lint and seeded-upgrade need a base commit to compare against.
 
 #### Inputs
 

--- a/examples/migration-checks-poetry.md
+++ b/examples/migration-checks-poetry.md
@@ -24,7 +24,12 @@ jobs:
       contents: read
 ```
 
-### With a pgvector service and SQL seeds
+### With SQL seeds
+
+Seeds run after `alembic upgrade head` at the base ref, so they must only
+target tables that the migrations create. Data for tables created at
+application runtime (for example a vector store table auto-created by an ORM
+or embedding library) will not exist yet and should not be seeded here.
 
 ```yaml
 jobs:
@@ -36,6 +41,6 @@ jobs:
       postgres_service: postgres
       seed_command: |
         for f in seeds/seed_*.sql; do
-          PGPASSWORD=postgres psql -h localhost -U postgres -d spec-rag -v ON_ERROR_STOP=1 -f "$f"
+          PGPASSWORD=postgres psql -h localhost -U postgres -d my-app -v ON_ERROR_STOP=1 -f "$f"
         done
 ```

--- a/examples/migration-checks-poetry.md
+++ b/examples/migration-checks-poetry.md
@@ -8,11 +8,11 @@ The Alembic sibling of [migration-checks-npm.yml](../.github/workflows/migration
 - **migrate-roundtrip** — `alembic upgrade head` → `alembic downgrade base` → `alembic upgrade head` against a fresh database, exercising every `downgrade()`.
 - **seeded-upgrade** — upgrade and seed at the **base ref**, then apply only the PR's new revisions on top, reproducing the deploy-time upgrade against existing data.
 
-`contents: read` is all that is required. The job must run on a `pull_request` event; the lint and seeded-upgrade jobs compare against `github.base_ref` and self-skip when it is empty.
+`contents: read` is all that is required. The workflow runs on both `pull_request` and `push` callers: on `pull_request` it compares the PR base against the PR head, and on `push` (for example a `release.yml` on `main`) it compares the commit before the push against the pushed commit — so seeded-upgrade becomes a final "upgrade the previously deployed commit to this one" check. The single-head lint and `migrate-roundtrip` run on any event; the immutability lint and seeded-upgrade need a base to compare against.
 
 By default Postgres is started from the caller's own `docker-compose.yml` `postgres` service, so the CI database version matches what the application runs.
 
-The seeded-upgrade job no-ops when the base ref has no revisions yet, so the PR that introduces a repo's first revision passes cleanly; the job becomes active once at least one revision is on the base branch.
+The seeded-upgrade job no-ops when there is no base to compare against or when the base commit has no revisions yet, so the change that introduces a repo's first revision passes cleanly; the job becomes active once at least one revision is on the base.
 
 ### Minimal
 

--- a/examples/migration-checks-poetry.md
+++ b/examples/migration-checks-poetry.md
@@ -1,0 +1,39 @@
+# Migration checks (Poetry)
+
+## Using [migration-checks-poetry.yml](../.github/workflows/migration-checks-poetry.yml) in callers
+
+The Alembic sibling of [migration-checks-npm.yml](../.github/workflows/migration-checks.md). Runs three jobs against a Poetry + Alembic project on `pull_request`:
+
+- **lint-migrations** — merged revisions are immutable (no modify/rename/delete of a version file already on the base branch), and the revision graph must have exactly **one head**. Alembic orders revisions by `down_revision`, not filename, so the failure mode equivalent to a knex "reorder" is two revisions branching from the same parent and producing multiple heads; `alembic upgrade head` then refuses to run.
+- **migrate-roundtrip** — `alembic upgrade head` → `alembic downgrade base` → `alembic upgrade head` against a fresh database, exercising every `downgrade()`.
+- **seeded-upgrade** — upgrade and seed at the **base ref**, then apply only the PR's new revisions on top, reproducing the deploy-time upgrade against existing data.
+
+`contents: read` is all that is required. The job must run on a `pull_request` event; the lint and seeded-upgrade jobs compare against `github.base_ref` and self-skip when it is empty.
+
+By default Postgres is started from the caller's own `docker-compose.yml` `postgres` service, so the CI database version matches what the application runs.
+
+### Minimal
+
+```yaml
+jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-poetry.yml@main
+    permissions:
+      contents: read
+```
+
+### With a pgvector service and SQL seeds
+
+```yaml
+jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-poetry.yml@main
+    permissions:
+      contents: read
+    with:
+      postgres_service: postgres
+      seed_command: |
+        for f in seeds/seed_*.sql; do
+          PGPASSWORD=postgres psql -h localhost -U postgres -d spec-rag -v ON_ERROR_STOP=1 -f "$f"
+        done
+```

--- a/examples/migration-checks-poetry.md
+++ b/examples/migration-checks-poetry.md
@@ -12,6 +12,8 @@ The Alembic sibling of [migration-checks-npm.yml](../.github/workflows/migration
 
 By default Postgres is started from the caller's own `docker-compose.yml` `postgres` service, so the CI database version matches what the application runs.
 
+The seeded-upgrade job no-ops when the base ref has no revisions yet, so the PR that introduces a repo's first revision passes cleanly; the job becomes active once at least one revision is on the base branch.
+
 ### Minimal
 
 ```yaml

--- a/examples/migration-checks-poetry.md
+++ b/examples/migration-checks-poetry.md
@@ -2,7 +2,7 @@
 
 ## Using [migration-checks-poetry.yml](../.github/workflows/migration-checks-poetry.yml) in callers
 
-The Alembic sibling of [migration-checks-npm.yml](../.github/workflows/migration-checks.md). Runs three jobs against a Poetry + Alembic project on `pull_request`:
+The Alembic sibling of [migration-checks-npm.yml](../.github/workflows/migration-checks-npm.yml). Runs three jobs against a Poetry + Alembic project:
 
 - **lint-migrations** — merged revisions are immutable (no modify/rename/delete of a version file already on the base branch), and the revision graph must have exactly **one head**. Alembic orders revisions by `down_revision`, not filename, so the failure mode equivalent to a knex "reorder" is two revisions branching from the same parent and producing multiple heads; `alembic upgrade head` then refuses to run.
 - **migrate-roundtrip** — `alembic upgrade head` → `alembic downgrade base` → `alembic upgrade head` against a fresh database, exercising every `downgrade()`.

--- a/examples/migration-checks.md
+++ b/examples/migration-checks.md
@@ -42,7 +42,7 @@ jobs:
 
 ### Image fallback
 
-For a repo with no postgres service in its compose file, provision a service container from an image instead. The CI version then no longer tracks the app, so prefer the compose service where one exists.
+For a repo with no postgres service in its compose file — or one whose compose file cannot be brought up in CI without extra bootstrap (for example bind-mounted TLS certs or required environment variables, since `docker compose up <service>` still validates the whole file) — provision a service container from an image instead. The CI version then no longer tracks the app, so pin it to match the compose image and prefer the compose service where one starts cleanly.
 
 ```yaml
 jobs:

--- a/examples/migration-checks.md
+++ b/examples/migration-checks.md
@@ -8,13 +8,25 @@ Runs three jobs against a knex project on `pull_request`:
 - **migrate-roundtrip** — `migrate:latest` → `migrate:rollback` → `migrate:latest` against a fresh database, so broken or asymmetric `down()` functions surface here.
 - **seeded-upgrade** — migrate and seed the database at the **base ref**, then apply only the PR's new migrations on top. This reproduces what deployment does (migrating a database that already has data), which an empty-database CI run never exercises.
 
-`contents: read` is all that is required. The job must run on a `pull_request` event: the lint and seeded-upgrade jobs compare against `github.base_ref`, and self-skip when it is empty.
+`contents: read` is all that is required. The workflow runs on both `pull_request` and `push` callers: on `pull_request` it compares the PR base against the PR head, and on `push` (for example a `release.yml` on `main`) it compares the commit before the push against the pushed commit — so seeded-upgrade becomes a final "upgrade the previously deployed commit to this one" check. `migrate-roundtrip` runs on any event.
 
 By default Postgres is started from the caller's own `docker-compose.yml` `postgres` service, so the CI database version matches what the application runs (and is kept current by renovate).
 
-The seeded-upgrade job no-ops when the base ref has no migrations yet, so the PR that introduces a repo's first migration passes cleanly; the job becomes active once at least one migration is on the base branch.
+The seeded-upgrade job no-ops when there is no base to compare against (a first push to a new branch) or when the base commit has no migrations yet, so the change that introduces a repo's first migration passes cleanly; the job becomes active once at least one migration is on the base.
 
-### Minimal
+### Minimal (pull request)
+
+```yaml
+jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+```
+
+### Final check on release (push to main)
+
+Called from a `push`-triggered `release.yml`, seeded-upgrade migrates the previously deployed commit's schema and data, then applies the migrations introduced by this push on top — the same upgrade the deploy is about to perform.
 
 ```yaml
 jobs:

--- a/examples/migration-checks.md
+++ b/examples/migration-checks.md
@@ -1,0 +1,54 @@
+# Migration checks
+
+## Using [migration-checks-npm.yml](../.github/workflows/migration-checks-npm.yml) in callers
+
+Runs three jobs against a knex project on `pull_request`:
+
+- **lint-migrations** — merged migrations are immutable (no modify/rename/delete of a file already on the base branch), and any new migration must sort after the newest existing one.
+- **migrate-roundtrip** — `migrate:latest` → `migrate:rollback` → `migrate:latest` against a fresh database, so broken or asymmetric `down()` functions surface here.
+- **seeded-upgrade** — migrate and seed the database at the **base ref**, then apply only the PR's new migrations on top. This reproduces what deployment does (migrating a database that already has data), which an empty-database CI run never exercises.
+
+`contents: read` is all that is required. The job must run on a `pull_request` event: the lint and seeded-upgrade jobs compare against `github.base_ref`, and self-skip when it is empty.
+
+By default Postgres is started from the caller's own `docker-compose.yml` `postgres` service, so the CI database version matches what the application runs (and is kept current by renovate).
+
+### Minimal
+
+```yaml
+jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+```
+
+### Custom compose service and seed
+
+Point the workflow at a specific compose service and provide smoke seed data so the seeded-upgrade job runs against representative rows.
+
+```yaml
+jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+    with:
+      migrations_dir: db/migrations
+      postgres_service: postgres
+      seed_command: npm run db:seed
+```
+
+### Image fallback
+
+For a repo with no postgres service in its compose file, provision a service container from an image instead. The CI version then no longer tracks the app, so prefer the compose service where one exists.
+
+```yaml
+jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+    with:
+      postgres_image: pgvector/pgvector:pg18
+      db_name: my-app
+```

--- a/examples/migration-checks.md
+++ b/examples/migration-checks.md
@@ -12,6 +12,8 @@ Runs three jobs against a knex project on `pull_request`:
 
 By default Postgres is started from the caller's own `docker-compose.yml` `postgres` service, so the CI database version matches what the application runs (and is kept current by renovate).
 
+The seeded-upgrade job no-ops when the base ref has no migrations yet, so the PR that introduces a repo's first migration passes cleanly; the job becomes active once at least one migration is on the base branch.
+
 ### Minimal
 
 ```yaml


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [ ] Bug Fix
- [ ] Chore
- [x] Feature
- [x] Documentation Update

## Linked tickets

[ENG-313](https://digicatapult.atlassian.net/browse/ENG-313)

## High level description

Adds a pair of reusable workflows — `migration-checks-npm.yml` (knex) and `migration-checks-poetry.yml` (Alembic) — that catch bad database migrations in CI before they reach a deploy.

## Detailed description

Our CI only ever migrates an empty database, and in production migrations run at container startup, so the first time a migration runs against a database that already contains data is at deploy time. Whole classes of migration problem are invisible until then: data-dependent failures (a statement that only errors once rows exist), migrations that cannot be rolled back, and edits to already-applied migration files that desync migration state across environments.

These workflows move those checks into CI. Each provides three jobs on `pull_request`:

- **lint-migrations** — merged migrations are immutable (no modify/rename/delete of a file already on the base branch); knex requires new migrations to sort after existing ones, Alembic requires the revision graph to have exactly one head.
- **migrate-roundtrip** — up / down / up against a fresh database, surfacing broken or asymmetric `down()` / `downgrade()`.
- **seeded-upgrade** — migrate and seed at the base ref, then apply only the PR's new migrations on top, reproducing a deploy against existing data.

Postgres is provisioned from the caller's own `docker-compose.yml` `postgres` service by default, so the CI database version tracks what the application actually runs (kept current by renovate), with a `postgres_image` service-container fallback for repos without a compose postgres service.

Validated end-to-end (both stacks) on hello-world, and wired into testbed-portal (npm), veritable-cloudagent (npm) and spec-rag-api (poetry) via branch-pinned caller PRs. Those callers point at this branch until it merges, after which their `uses:` references flip to `@main`.

## Describe alternatives you've considered

SQL-level linters (squawk, Atlas `migrate lint`) operate on raw SQL, not knex/alembic modules, so they are not a drop-in here. A hardcoded service-container image was considered but drifts from the app's actual Postgres version; the compose-service default keeps them aligned via renovate.

## Operational impact

Additive: new reusable workflows plus docs. No existing workflow changes. Callers opt in on a `pull_request` trigger; the DB-backed jobs need Docker Compose (already present on GitHub-hosted runners) and a `postgres` service in the caller's compose file, or the image fallback.

## Additional context

N/A


[ENG-313]: https://digicatapult.atlassian.net/browse/ENG-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ