### PR TITLE
Drop unused AF inputs and upload ZAP artefacts

### DIFF
--- a/.github/workflows/scan-zap.yml
+++ b/.github/workflows/scan-zap.yml
@@ -195,55 +195,74 @@ jobs:
       - name: Extract ZAP AF report paths
         if: matrix.scan_type == 'automation-framework'
         id: report_paths
-        continue-on-error: true
         env:
           PLAN_FILE: ${{ inputs.automation_plan }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
-          declare -A EXT_MAP=(
-            [risk-confidence-html]=html
-            [modern-html]=html
-            [traditional-html]=html
-            [traditional-html-plus]=html
-            [traditional-json]=json
-            [traditional-json-plus]=json
-            [traditional-json-min]=json
-            [traditional-md]=md
-            [traditional-xml]=xml
-            [traditional-xml-plus]=xml
-            [traditional-pdf]=pdf
-            [sarif-json]=json
-          )
+          paths=$(
+            set -euo pipefail
 
-          reports_json=$(yq -o=json '[(.jobs // []) | .[] | select(.type == "report")]' "$PLAN_FILE")
-          count=$(echo "$reports_json" | jq 'length')
+            declare -A EXT_MAP=(
+              [risk-confidence-html]=html
+              [modern-html]=html
+              [traditional-html]=html
+              [traditional-html-plus]=html
+              [traditional-json]=json
+              [traditional-json-plus]=json
+              [traditional-json-min]=json
+              [traditional-md]=md
+              [traditional-xml]=xml
+              [traditional-xml-plus]=xml
+              [traditional-pdf]=pdf
+              [sarif-json]=json
+            )
 
-          paths_file=$(mktemp)
-          for ((i = 0; i < count; i++)); do
-            report_dir=$(echo "$reports_json" | jq -r ".[$i].parameters.reportDir // \"\"")
-            report_file=$(echo "$reports_json" | jq -r ".[$i].parameters.reportFile // \"{{yyyy-MM-dd}}-ZAP-Report-[[site]]\"")
-            template=$(echo "$reports_json" | jq -r ".[$i].parameters.template // \"risk-confidence-html\"")
-            ext="${EXT_MAP[$template]:-html}"
+            reports_json=$(yq -o=json '[(.jobs // []) | .[] | select(.type == "report")]' "$PLAN_FILE")
+            count=$(echo "$reports_json" | jq 'length')
 
-            # action-af maps the container's /zap/wrk directory to $GITHUB_WORKSPACE
-            rel_dir="${report_dir#/zap/wrk}"
-            rel_dir="${rel_dir#/}"
-
-            # reportFile may contain {{...}} / [[...]] placeholders resolved at runtime; glob-match them
-            report_file_glob=$(echo "$report_file" | sed -E 's/\{\{[^}]*\}\}/*/g; s/\[\[[^]]*\]\]/*/g')
-
-            if [ -n "$rel_dir" ]; then
-              full_path="$GITHUB_WORKSPACE/$rel_dir/${report_file_glob}.${ext}"
-            else
-              full_path="$GITHUB_WORKSPACE/${report_file_glob}.${ext}"
+            if [ "$count" -eq 0 ]; then
+              # No report jobs in the plan - a legitimate, expected skip.
+              exit 0
             fi
-            echo "$full_path" >> "$paths_file"
-          done
+
+            paths_file=$(mktemp)
+            for ((i = 0; i < count; i++)); do
+              report_dir=$(echo "$reports_json" | jq -r ".[$i].parameters.reportDir // \"\"")
+              report_file=$(echo "$reports_json" | jq -r ".[$i].parameters.reportFile // \"{{yyyy-MM-dd}}-ZAP-Report-[[site]]\"")
+              template=$(echo "$reports_json" | jq -r ".[$i].parameters.template // \"risk-confidence-html\"")
+              ext="${EXT_MAP[$template]:-html}"
+
+              # action-af maps the container's /zap/wrk directory to $GITHUB_WORKSPACE
+              rel_dir="${report_dir#/zap/wrk}"
+              rel_dir="${rel_dir#/}"
+
+              # reportFile may contain {{...}} / [[...]] placeholders resolved at runtime; glob-match them
+              report_file_glob=$(echo "$report_file" | sed -E 's/\{\{[^}]*\}\}/*/g; s/\[\[[^]]*\]\]/*/g')
+
+              if [ -n "$rel_dir" ]; then
+                full_path="$GITHUB_WORKSPACE/$rel_dir/${report_file_glob}.${ext}"
+              else
+                full_path="$GITHUB_WORKSPACE/${report_file_glob}.${ext}"
+              fi
+              echo "$full_path" >> "$paths_file"
+            done
+
+            if [ ! -s "$paths_file" ]; then
+              echo "::warning::found $count report job(s) in the automation plan but resolved 0 report paths" >&2
+            fi
+
+            cat "$paths_file"
+          )
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::report extraction issue: failed to parse automation plan or resolve report paths (check yq/jq availability and plan structure)" >&2
+            paths=""
+          fi
 
           {
             echo "paths<<REPORT_PATHS_EOF"
-            cat "$paths_file"
+            echo "$paths"
             echo "REPORT_PATHS_EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Upload ZAP Automation Framework report

--- a/.github/workflows/scan-zap.yml
+++ b/.github/workflows/scan-zap.yml
@@ -198,6 +198,7 @@ jobs:
         env:
           PLAN_FILE: ${{ inputs.automation_plan }}
         run: |
+          set +e
           set -uo pipefail
 
           paths=$(
@@ -249,13 +250,17 @@ jobs:
             done
 
             if [ ! -s "$paths_file" ]; then
-              echo "::warning::found $count report job(s) in the automation plan but resolved 0 report paths" >&2
+              echo "::error::found $count report job(s) in the automation plan but resolved 0 report paths" >&2
+              exit 2
             fi
 
             cat "$paths_file"
           )
           rc=$?
-          if [ "$rc" -ne 0 ]; then
+          if [ "$rc" -eq 2 ]; then
+            # report job(s) declared in the plan but path resolution produced nothing
+            exit 1
+          elif [ "$rc" -ne 0 ]; then
             echo "::warning::report extraction issue: failed to parse automation plan or resolve report paths (check yq/jq availability and plan structure)" >&2
             paths=""
           fi
@@ -271,4 +276,4 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.report_paths.outputs.paths }}
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/scan-zap.yml
+++ b/.github/workflows/scan-zap.yml
@@ -61,6 +61,10 @@ on:
         required: false
         type: string
         default: ""
+      docker_env_vars:
+        required: false
+        type: string
+        default: ""
 jobs:
   zap-scan:
     name: ZAP ${{ matrix.scan_type }} scan
@@ -186,7 +190,66 @@ jobs:
         with:
           plan: ${{ inputs.automation_plan }}
           docker_name: ${{ inputs.docker_name }}
+          docker_env_vars: ${{ inputs.docker_env_vars }}
           cmd_options: ${{ inputs.cmd_options }}
-          rules_file_name: ${{ inputs.rules_file_name }}
-          fail_action: ${{ inputs.fail_action }}
-          artifact_name: ${{ steps.artifact.outputs.name }}
+      - name: Extract ZAP AF report paths
+        if: matrix.scan_type == 'automation-framework'
+        id: report_paths
+        continue-on-error: true
+        env:
+          PLAN_FILE: ${{ inputs.automation_plan }}
+        run: |
+          set -euo pipefail
+
+          declare -A EXT_MAP=(
+            [risk-confidence-html]=html
+            [modern-html]=html
+            [traditional-html]=html
+            [traditional-html-plus]=html
+            [traditional-json]=json
+            [traditional-json-plus]=json
+            [traditional-json-min]=json
+            [traditional-md]=md
+            [traditional-xml]=xml
+            [traditional-xml-plus]=xml
+            [traditional-pdf]=pdf
+            [sarif-json]=json
+          )
+
+          reports_json=$(yq -o=json '[(.jobs // []) | .[] | select(.type == "report")]' "$PLAN_FILE")
+          count=$(echo "$reports_json" | jq 'length')
+
+          paths_file=$(mktemp)
+          for ((i = 0; i < count; i++)); do
+            report_dir=$(echo "$reports_json" | jq -r ".[$i].parameters.reportDir // \"\"")
+            report_file=$(echo "$reports_json" | jq -r ".[$i].parameters.reportFile // \"{{yyyy-MM-dd}}-ZAP-Report-[[site]]\"")
+            template=$(echo "$reports_json" | jq -r ".[$i].parameters.template // \"risk-confidence-html\"")
+            ext="${EXT_MAP[$template]:-html}"
+
+            # action-af maps the container's /zap/wrk directory to $GITHUB_WORKSPACE
+            rel_dir="${report_dir#/zap/wrk}"
+            rel_dir="${rel_dir#/}"
+
+            # reportFile may contain {{...}} / [[...]] placeholders resolved at runtime; glob-match them
+            report_file_glob=$(echo "$report_file" | sed -E 's/\{\{[^}]*\}\}/*/g; s/\[\[[^]]*\]\]/*/g')
+
+            if [ -n "$rel_dir" ]; then
+              full_path="$GITHUB_WORKSPACE/$rel_dir/${report_file_glob}.${ext}"
+            else
+              full_path="$GITHUB_WORKSPACE/${report_file_glob}.${ext}"
+            fi
+            echo "$full_path" >> "$paths_file"
+          done
+
+          {
+            echo "paths<<REPORT_PATHS_EOF"
+            cat "$paths_file"
+            echo "REPORT_PATHS_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Upload ZAP Automation Framework report
+        if: matrix.scan_type == 'automation-framework' && steps.report_paths.outputs.paths != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: ${{ steps.report_paths.outputs.paths }}
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -744,23 +744,24 @@ Runs OWASP ZAP Dynamic Application Security Testing (DAST) scans against a runni
 
 #### Inputs
 
-| Input               | Type    | Description                                                                                          | Default                            | Required |
-| ------------------- | ------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
-| matrix_scans        | string  | JSON array of ZAP scan types to run: `baseline`, `full`, `api`, `automation-framework`               | `'["baseline"]'`                   | false    |
-| target              | string  | URL of the web application to scan (used by `baseline`, `full`, and `api` scan types)                | `http://localhost:3000`            | false    |
-| env_vars            | string  | JSON object of extra environment variables to inject                                                 | `{}`                               | false    |
-| docker_compose_file | string  | Docker Compose file used to bring up the application stack before scanning                           | `""`                               | false    |
-| pull_ghcr           | boolean | Log in to GitHub Container Registry before pulling images (e.g. if using private/custom proxy image) | `false`                            | false    |
-| pre_scan_command    | string  | Arbitrary shell command to start the application (e.g. `npm ci && npm start &`)                      | `""`                               | false    |
-| target_wait_timeout | number  | Seconds to poll `target` for a successful response before failing                                    | `60`                               | false    |
-| rules_file_name     | string  | Relative path to a ZAP rules TSV file for suppressing known alerts                                   | `""`                               | false    |
-| cmd_options         | string  | Additional ZAP CLI options passed to all scan types                                                  | `""`                               | false    |
-| docker_name         | string  | Custom ZAP Docker image name; defaults to the stable ZAP image                                       | `"ghcr.io/zaproxy/zaproxy:stable"` | false    |
-| allow_issue_writing | boolean | Create or update a GitHub issue in the repository with ZAP findings; requires `issues: write`        | `false`                            | false    |
-| fail_action         | boolean | Fail the job if ZAP identifies any alerts                                                            | `false`                            | false    |
-| artifact_name       | string  | Base name for uploaded scan report artifacts; suffixed with the scan type (e.g. `zap_scan-baseline`) | `zap_scan`                         | false    |
-| api_scan_format     | string  | API definition format for the `api` scan type: `openapi`, `soap`, or `graphql`                       | `openapi`                          | false    |
-| automation_plan     | string  | File path or URL of the ZAP Automation Framework plan; required when using `automation-framework`    | `""`                               | false    |
+| Input               | Type    | Description                                                                                                                  | Default                            | Required |
+| ------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- |
+| matrix_scans        | string  | JSON array of ZAP scan types to run: `baseline`, `full`, `api`, `automation-framework`                                       | `'["baseline"]'`                   | false    |
+| target              | string  | URL of the web application to scan (used by `baseline`, `full`, and `api` scan types)                                        | `http://localhost:3000`            | false    |
+| env_vars            | string  | JSON object of extra environment variables to inject                                                                         | `{}`                               | false    |
+| docker_compose_file | string  | Docker Compose file used to bring up the application stack before scanning                                                   | `""`                               | false    |
+| pull_ghcr           | boolean | Log in to GitHub Container Registry before pulling images (e.g. if using private/custom proxy image)                         | `false`                            | false    |
+| pre_scan_command    | string  | Arbitrary shell command to start the application (e.g. `npm ci && npm start &`)                                              | `""`                               | false    |
+| target_wait_timeout | number  | Seconds to poll `target` for a successful response before failing                                                            | `60`                               | false    |
+| rules_file_name     | string  | Relative path to a ZAP rules TSV file for suppressing known alerts; applies to `baseline`, `full`, and `api` scan types only | `""`                               | false    |
+| cmd_options         | string  | Additional ZAP CLI options passed to all scan types                                                                          | `""`                               | false    |
+| docker_name         | string  | Custom ZAP Docker image name; defaults to the stable ZAP image                                                               | `"ghcr.io/zaproxy/zaproxy:stable"` | false    |
+| allow_issue_writing | boolean | Create or update a GitHub issue in the repository with ZAP findings; requires `issues: write`                                | `false`                            | false    |
+| fail_action         | boolean | Fail the job if ZAP identifies any alerts; applies to `baseline`, `full`, and `api` scan types only                          | `false`                            | false    |
+| artifact_name       | string  | Base name for uploaded scan report artifacts; suffixed with the scan type (e.g. `zap_scan-baseline`)                         | `zap_scan`                         | false    |
+| api_scan_format     | string  | API definition format for the `api` scan type: `openapi`, `soap`, or `graphql`                                               | `openapi`                          | false    |
+| automation_plan     | string  | File path or URL of the ZAP Automation Framework plan; required when using `automation-framework`                            | `""`                               | false    |
+| docker_env_vars     | string  | Newline-separated names of environment variables, used only by the `automation-framework` scan type                          | `""`                               | false    |
 
 #### Permissions
 
@@ -779,3 +780,4 @@ This GitHub Actions workflow runs OWASP ZAP DAST scans against a locally running
 3. **Run Pre-Scan Command** _(optional)_: Executes `pre_scan_command` on the runner for use cases where the application is started directly rather than via Docker Compose.
 4. **Wait for Target** _(skipped for `automation-framework`)_: Polls `target` with `curl` at two-second intervals until it responds successfully or `target_wait_timeout` is reached.
 5. **ZAP Scan**: Runs the selected ZAP action for each `matrix.scan_type`. Report artifacts are uploaded under `artifact_name-<scan_type>` to avoid collisions when multiple types run in parallel.
+6. **Upload Automation Framework Report** _(only for `automation-framework`)_: Parses `automation_plan` for any `report` jobs, locates the generated report file(s) on the runner (via the `/zap/wrk` → `$GITHUB_WORKSPACE` mapping), and uploads them as an artifact under `artifact_name-automation-framework`.

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ Runs OWASP ZAP Dynamic Application Security Testing (DAST) scans against a runni
 | fail_action         | boolean | Fail the job if ZAP identifies any alerts; applies to `baseline`, `full`, and `api` scan types only                          | `false`                            | false    |
 | artifact_name       | string  | Base name for uploaded scan report artifacts; suffixed with the scan type (e.g. `zap_scan-baseline`)                         | `zap_scan`                         | false    |
 | api_scan_format     | string  | API definition format for the `api` scan type: `openapi`, `soap`, or `graphql`                                               | `openapi`                          | false    |
-| automation_plan     | string  | File path or URL of the ZAP Automation Framework plan; required when using `automation-framework`                            | `""`                               | false    |
+| automation_plan     | string  | File path of the ZAP Automation Framework plan; required when using `automation-framework`                                   | `""`                               | false    |
 | docker_env_vars     | string  | Newline-separated names of environment variables, used only by the `automation-framework` scan type                          | `""`                               | false    |
 
 #### Permissions

--- a/examples/scan-zap.md
+++ b/examples/scan-zap.md
@@ -78,6 +78,10 @@ jobs:
 
 The `automation-framework` type does not use `target`; instead it requires an `automation_plan` file path checked in to the repository. The wait-for-URL step is skipped for this scan type.
 
+Any `report` jobs defined in the plan are automatically located after the scan (by parsing the plan's `reportDir`/`reportFile`/`template` parameters) and uploaded as a workflow artifact (`zap_scan-automation-framework` by default), since ZAP writes them to the runner via the `/zap/wrk` -> `$GITHUB_WORKSPACE` mapping rather than exposing them directly.
+
+If your plan needs specific environment variables available inside the ZAP container (e.g. for authentication), set them via `env_vars` and list their names in `docker_env_vars`.
+
 ```yaml
 jobs:
   scan-zap:
@@ -89,6 +93,9 @@ jobs:
       matrix_scans: '["automation-framework"]'
       automation_plan: ".zap/plan.yml"
       docker_compose_file: docker-compose.yml
+      env_vars: '{"ZAP_AUTH_HEADER_VALUE": "Bearer some-token"}'
+      docker_env_vars: |
+        ZAP_AUTH_HEADER_VALUE
 ```
 
 ### Pulling images from GHCR


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

- ENG-300
- ENG-305

## High level description

Certain inputs to the ZAP Automation Framework were actually non-functional. They've been removed from it. Conversely, one input was found to be missing: `docker_env_vars`. The ZAP AF workflow also doesn't upload the artefacts generated, hence there needs to be additional wiring with `jq`/`yq` to read the automation plan file, infer the path of the report, and then upload it via some first-party action.

[testbed-portal](https://github.com/digicatapult/testbed-portal/pull/75) was used to try and authenticate using the ZAP Automation Framework workflow. Both issues arose there.