### PR TITLE
Upload ZAP AF report even when the scan fails

### DIFF
--- a/.github/workflows/scan-zap.yml
+++ b/.github/workflows/scan-zap.yml
@@ -193,7 +193,7 @@ jobs:
           docker_env_vars: ${{ inputs.docker_env_vars }}
           cmd_options: ${{ inputs.cmd_options }}
       - name: Extract ZAP AF report paths
-        if: matrix.scan_type == 'automation-framework'
+        if: ${{ !cancelled() && matrix.scan_type == 'automation-framework' }}
         id: report_paths
         env:
           PLAN_FILE: ${{ inputs.automation_plan }}
@@ -271,7 +271,7 @@ jobs:
             echo "REPORT_PATHS_EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Upload ZAP Automation Framework report
-        if: matrix.scan_type == 'automation-framework' && steps.report_paths.outputs.paths != ''
+        if: ${{ !cancelled() && matrix.scan_type == 'automation-framework' && steps.report_paths.outputs.paths != '' }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifact.outputs.name }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

- ENG-300
- ENG-305

## High level description

Follow-up to #116. The ZAP Automation Framework report is still lost whenever the scan fails on findings, which is the case where the report matters most.

## Detailed description

`#116` added an `Extract ZAP AF report paths` step and an `Upload ZAP Automation Framework report` step, both guarded with `if: matrix.scan_type == 'automation-framework'`. Because that expression contains no status check function, GitHub wraps it in an implicit `success()`. When the `action-af` scan step exits non-zero (for example when a plan `exitStatus` job fails the run on a `High` alert), both steps are skipped and no artifact is uploaded.

This was observed on `testbed-portal#75` (run 30012983751): the plan's `exitStatus` job raised `High` and `Medium`, ZAP exited 1, `zap-authenticated-report.html` was generated on the runner, but there was no way to see which alerts fired because the report was never uploaded.

The fix guards both steps with `!cancelled()` so they run whether the scan passed or failed, while a genuinely failing scan still leaves the job red. `!cancelled()` is used rather than `always()` so a cancelled run does not attempt a pointless upload. The existing `steps.report_paths.outputs.paths != ''` clause continues to skip the upload cleanly when the plan declares no `report` jobs.

## Describe alternatives you've considered

`always()` would also work but would run the upload on cancellation, which is wasteful and can surface confusing failures during a cancel.

## Operational impact

No input or interface changes. Consumers pinned to `@main` pick this up automatically. The only behavioural change is that a failed AF scan now also uploads its report artifact.

## Additional context

Validated against the hello-world canary (see linked test run in the PR thread), exercising an AF plan whose `exitStatus` fails the scan and confirming the report artifact is still uploaded.
