### PR TITLE
Set latest version during SBOM upload

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -5,6 +5,7 @@ on:
       dtrack_is_latest:
         required: false
         type: boolean
+        default: true
       dtrack_project_name:
         required: false
         type: string

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -2,6 +2,9 @@ name: Generate SBOM
 on:
   workflow_call:
     inputs:
+      dtrack_is_latest:
+        required: false
+        type: boolean
       dtrack_project_name:
         required: false
         type: string
@@ -212,3 +215,4 @@ jobs:
           bomfilename: ${{ steps.set-filename.outputs.filename }}
           autocreate: true
           parent: ${{ secrets.DTRACK_PARENT_GUID }}
+          isLatest: ${{ inputs.dtrack_is_latest }}

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ For backwards compatibility, the legacy filename [.github/workflows/generate-sbo
 
 | Input                  | Type    | Description                                                                                                                               | Default                               | Required |
 | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------- |
+| dtrack_is_latest       | boolean | An optional flag to mark the project as the latest version within Dependency Track                                                        | `true`                                | false    |
 | dtrack_project_name    | string  | A project name to use within Dependency Track                                                                                             | `${{ github.event.repository.name }}` | false    |
 | enable_check_version   | boolean | An option to enable the use of the digicatapult/check-version action                                                                      | `false`                               | false    |
 | enable_dtrack_project  | boolean | An option to enable the use of Dependency Track                                                                                           | `false`                               | false    |


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Feature

## Linked tickets

ENG-325

## High level description

A few weeks ago, Dependency-Track's developers exposed the `isLatest` flag within their SBOM upload action. This removes the need for extra cURL invocations to set "latest" on the most recent uploads or manual toggling within the GUI. It's been tested here: [digicatapult/hello-world](https://github.com/digicatapult/hello-world/pull/28).