### PR TITLE
Add Docker secrets for Scout auth

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -362,6 +362,8 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
+          dockerhub-user: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
           registry-user: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           image: ghcr.io/${{ needs.prepare.outputs.org_name }}/${{ needs.prepare.outputs.repo_name }}:${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

ENG-326

## High level description

We invoke Docker Scout twice in build-docker.yml, once with Docker secrets for a Docker-specific push (public) and then alternatively with GHCR (private). The latter doesn't currently use Docker secrets (`secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN`) even though they're available in the repository. What happens is that Docker Scout expects both secrets and fails with the following:

```bash
Downloading asset: docker-scout-action_linux_amd64 (173.5 MB)
Using binary: /home/runner/work/_actions/docker/scout-action/v1/dist/docker-scout-action_linux_amd64
Error: could not authenticate: user githubactions not entitled to use Docker Scout
```

Since we use the same secrets to authenticate elsewhere in the workflow for the corresponding public job, it should be a simple question of including them for GHCR.